### PR TITLE
Translate website content to English

### DIFF
--- a/IFRAMGAME.html
+++ b/IFRAMGAME.html
@@ -156,22 +156,22 @@
     </nav>
     <div class="content">
         <section class="section">
-            <h2 class="section-title">🌐 IFRAME游戏平台入口</h2>
+            <h2 class="section-title">🌐 IFRAME Platform Directory</h2>
             <div class="platform-list">
                 <div class="platform-item">
-                    <span>CrazyGames 新游戏：</span>
+                    <span>CrazyGames – New Releases:</span>
                     <a href="https://www.crazygames.com/new" target="_blank">https://www.crazygames.com/new</a>
                 </div>
                 <div class="platform-item">
-                    <span>GameDistribution 游戏库：</span>
+                    <span>GameDistribution – Game Library:</span>
                     <a href="https://gamedistribution.com/games/" target="_blank">https://gamedistribution.com/games/</a>
                 </div>
                 <div class="platform-item">
-                    <span>Scratch 全部项目：</span>
+                    <span>Scratch – All Projects:</span>
                     <a href="https://scratch.mit.edu/explore/projects/all/" target="_blank">https://scratch.mit.edu/explore/projects/all/</a>
                 </div>
                 <div class="platform-item">
-                    <span>MiniPlay 最受欢迎：</span>
+                    <span>MiniPlay – Most Played:</span>
                     <a href="https://www.miniplay.com/most-played" target="_blank">https://www.miniplay.com/most-played</a>
                 </div>
                 <div class="platform-item">
@@ -181,8 +181,8 @@
             </div>
         </section>
         <section class="section">
-            <h2 class="section-title">📢 说明</h2>
-            <p>本页面收录了主流 IFRAME 游戏平台的入口，方便快速访问和录入新游戏。你可以点击上方链接，浏览并挑选喜欢的 IFRAME 游戏。</p>
+            <h2 class="section-title">📢 Overview</h2>
+            <p>This page collects quick links to leading IFRAME game platforms so you can browse catalogs and add new games efficiently. Explore the resources above to discover experiences that fit your audience.</p>
         </section>
     </div>
     <footer class="footer">

--- a/company-ranking.html
+++ b/company-ranking.html
@@ -3,13 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="全球游戏公司排行榜 - 腾讯游戏、网易游戏、米哈游等知名游戏开发公司排名。了解游戏开发公司收入、游戏制作技术、游戏引擎使用情况。">
-    <meta name="keywords" content="游戏公司排行榜,游戏开发公司,腾讯游戏,网易游戏,米哈游,游戏制作,游戏开发,游戏引擎,Unity游戏开发,Unreal游戏开发">
-    <meta name="author" content="游戏工作室">
+    <meta name="description" content="Global game company rankings featuring industry leaders such as Tencent, NetEase, miHoYo, and more. Explore revenue insights, production strengths, and engine expertise.">
+    <meta name="keywords" content="game company rankings, game developers, Tencent, NetEase, miHoYo, game production, game development, game engines, Unity, Unreal">
+    <meta name="author" content="Game Studio">
     <meta name="robots" content="index, follow">
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437"
      crossorigin="anonymous"></script>
-    <title>游戏公司排行榜 - 全球游戏开发公司排名 | 游戏制作公司收入对比</title>
+    <title>Game Company Rankings - Global Game Developers & Revenue Comparison</title>
     <style>
         * {
             margin: 0;
@@ -317,184 +317,184 @@
 
     <div class="content">
         <section class="section">
-            <h2 class="section-title">🏆 全球游戏公司排行榜</h2>
+            <h2 class="section-title">🏆 Global Game Company Rankings</h2>
             <div class="category-tabs">
-                <button class="category-tab active" onclick="filterCompanies('all')">全部公司</button>
-                <button class="category-tab" onclick="filterCompanies('chinese')">中国公司</button>
-                <button class="category-tab" onclick="filterCompanies('international')">国际公司</button>
+                <button class="category-tab active" onclick="filterCompanies('all')">All Companies</button>
+                <button class="category-tab" onclick="filterCompanies('chinese')">Chinese Companies</button>
+                <button class="category-tab" onclick="filterCompanies('international')">International Companies</button>
             </div>
-            
+
             <div class="ranking-grid" id="companiesGrid">
-                <!-- 中国公司 -->
+                <!-- Chinese companies -->
                 <div class="company-card" data-category="chinese">
                     <div class="company-header">
-                        <img src="https://picsum.photos/80/80?random=1" alt="腾讯游戏LOGO" class="company-logo">
+                        <img src="https://picsum.photos/80/80?random=1" alt="Tencent Games logo" class="company-logo">
                         <div>
                             <div class="company-rank">#1</div>
-                            <div class="company-name">腾讯游戏</div>
-                            <div class="company-name-en">Tencent Games</div>
+                            <div class="company-name">Tencent Games</div>
+                            <div class="company-name-en">Global leader in mobile and online gaming</div>
                         </div>
                     </div>
-                    <div class="company-description">全球最大的游戏公司之一，拥有《王者荣耀》、《和平精英》等热门游戏。</div>
+                    <div class="company-description">Tencent operates blockbuster franchises such as Honor of Kings and PUBG Mobile, and invests in studios worldwide.</div>
                     <div class="company-info">
-                        <span class="company-country">🇨🇳 中国</span>
-                        <span class="company-revenue">年收入: $27.3B</span>
+                        <span class="company-country">🇨🇳 China</span>
+                        <span class="company-revenue">Annual revenue: $27.3B</span>
                     </div>
-                    <a href="https://game.qq.com/" class="company-link" target="_blank">访问官网</a>
+                    <a href="https://game.qq.com/" class="company-link" target="_blank">Visit Website</a>
                 </div>
 
                 <div class="company-card" data-category="chinese">
                     <div class="company-header">
-                        <img src="https://picsum.photos/80/80?random=2" alt="网易游戏LOGO" class="company-logo">
+                        <img src="https://picsum.photos/80/80?random=2" alt="NetEase Games logo" class="company-logo">
                         <div>
                             <div class="company-rank">#2</div>
-                            <div class="company-name">网易游戏</div>
-                            <div class="company-name-en">NetEase Games</div>
+                            <div class="company-name">NetEase Games</div>
+                            <div class="company-name-en">Creators of Fantasy Westward Journey and Onmyoji</div>
                         </div>
                     </div>
-                    <div class="company-description">中国领先的游戏开发商，代表作包括《梦幻西游》、《阴阳师》等。</div>
+                    <div class="company-description">NetEase focuses on premium MMORPG and mobile experiences, expanding globally with self-developed and licensed titles.</div>
                     <div class="company-info">
-                        <span class="company-country">🇨🇳 中国</span>
-                        <span class="company-revenue">年收入: $9.7B</span>
+                        <span class="company-country">🇨🇳 China</span>
+                        <span class="company-revenue">Annual revenue: $9.7B</span>
                     </div>
-                    <a href="https://game.163.com/" class="company-link" target="_blank">访问官网</a>
+                    <a href="https://game.163.com/" class="company-link" target="_blank">Visit Website</a>
                 </div>
 
                 <div class="company-card" data-category="chinese">
                     <div class="company-header">
-                        <img src="https://picsum.photos/80/80?random=3" alt="米哈游LOGO" class="company-logo">
+                        <img src="https://picsum.photos/80/80?random=3" alt="miHoYo logo" class="company-logo">
                         <div>
                             <div class="company-rank">#3</div>
-                            <div class="company-name">米哈游</div>
-                            <div class="company-name-en">miHoYo</div>
+                            <div class="company-name">miHoYo</div>
+                            <div class="company-name-en">Makers of Genshin Impact and Honkai</div>
                         </div>
                     </div>
-                    <div class="company-description">以《原神》、《崩坏》系列闻名的二次元游戏开发商。</div>
+                    <div class="company-description">miHoYo delivers anime-inspired open worlds and live-service storytelling that resonate with players worldwide.</div>
                     <div class="company-info">
-                        <span class="company-country">🇨🇳 中国</span>
-                        <span class="company-revenue">年收入: $3.8B</span>
+                        <span class="company-country">🇨🇳 China</span>
+                        <span class="company-revenue">Annual revenue: $3.8B</span>
                     </div>
-                    <a href="https://www.mihoyo.com/" class="company-link" target="_blank">访问官网</a>
+                    <a href="https://www.mihoyo.com/" class="company-link" target="_blank">Visit Website</a>
                 </div>
 
-                <!-- 国际公司 -->
+                <!-- International companies -->
                 <div class="company-card" data-category="international">
                     <div class="company-header">
-                        <img src="https://picsum.photos/80/80?random=4" alt="索尼互动娱乐LOGO" class="company-logo">
+                        <img src="https://picsum.photos/80/80?random=4" alt="Sony Interactive Entertainment logo" class="company-logo">
                         <div>
                             <div class="company-rank">#4</div>
-                            <div class="company-name">索尼互动娱乐</div>
-                            <div class="company-name-en">Sony Interactive Entertainment</div>
+                            <div class="company-name">Sony Interactive Entertainment</div>
+                            <div class="company-name-en">PlayStation studios and services</div>
                         </div>
                     </div>
-                    <div class="company-description">PlayStation平台的所有者，拥有《战神》、《最后生还者》等经典IP。</div>
+                    <div class="company-description">Sony operates the PlayStation ecosystem and award-winning franchises like God of War and The Last of Us.</div>
                     <div class="company-info">
-                        <span class="company-country">🇯🇵 日本</span>
-                        <span class="company-revenue">年收入: $24.4B</span>
+                        <span class="company-country">🇯🇵 Japan</span>
+                        <span class="company-revenue">Annual revenue: $24.4B</span>
                     </div>
-                    <a href="https://www.playstation.com/" class="company-link" target="_blank">访问官网</a>
+                    <a href="https://www.playstation.com/" class="company-link" target="_blank">Visit Website</a>
                 </div>
 
                 <div class="company-card" data-category="international">
                     <div class="company-header">
-                        <img src="https://picsum.photos/80/80?random=5" alt="微软游戏LOGO" class="company-logo">
+                        <img src="https://picsum.photos/80/80?random=5" alt="Microsoft Gaming logo" class="company-logo">
                         <div>
                             <div class="company-rank">#5</div>
-                            <div class="company-name">微软游戏</div>
-                            <div class="company-name-en">Microsoft Gaming</div>
+                            <div class="company-name">Microsoft Gaming</div>
+                            <div class="company-name-en">Xbox studios, Bethesda, and Activision Blizzard</div>
                         </div>
                     </div>
-                    <div class="company-description">Xbox平台所有者，收购了动视暴雪，拥有《我的世界》、《光环》等IP。</div>
+                    <div class="company-description">Microsoft drives the Xbox ecosystem with titles like Minecraft, Halo, and Call of Duty following the Activision Blizzard acquisition.</div>
                     <div class="company-info">
-                        <span class="company-country">🇺🇸 美国</span>
-                        <span class="company-revenue">年收入: $15.5B</span>
+                        <span class="company-country">🇺🇸 United States</span>
+                        <span class="company-revenue">Annual revenue: $15.5B</span>
                     </div>
-                    <a href="https://www.xbox.com/" class="company-link" target="_blank">访问官网</a>
+                    <a href="https://www.xbox.com/" class="company-link" target="_blank">Visit Website</a>
                 </div>
 
                 <div class="company-card" data-category="international">
                     <div class="company-header">
-                        <img src="https://picsum.photos/80/80?random=6" alt="任天堂LOGO" class="company-logo">
+                        <img src="https://picsum.photos/80/80?random=6" alt="Nintendo logo" class="company-logo">
                         <div>
                             <div class="company-rank">#6</div>
-                            <div class="company-name">任天堂</div>
-                            <div class="company-name-en">Nintendo</div>
+                            <div class="company-name">Nintendo</div>
+                            <div class="company-name-en">Creators of Mario, Zelda, and Pokémon</div>
                         </div>
                     </div>
-                    <div class="company-description">拥有《马里奥》、《塞尔达》、《宝可梦》等经典游戏系列。</div>
+                    <div class="company-description">Nintendo blends hardware and software innovation across the Switch platform with beloved family-friendly franchises.</div>
                     <div class="company-info">
-                        <span class="company-country">🇯🇵 日本</span>
-                        <span class="company-revenue">年收入: $12.1B</span>
+                        <span class="company-country">🇯🇵 Japan</span>
+                        <span class="company-revenue">Annual revenue: $12.1B</span>
                     </div>
-                    <a href="https://www.nintendo.com/" class="company-link" target="_blank">访问官网</a>
+                    <a href="https://www.nintendo.com/" class="company-link" target="_blank">Visit Website</a>
                 </div>
 
                 <div class="company-card" data-category="international">
                     <div class="company-header">
-                        <img src="https://picsum.photos/80/80?random=7" alt="动视暴雪LOGO" class="company-logo">
+                        <img src="https://picsum.photos/80/80?random=7" alt="Activision Blizzard logo" class="company-logo">
                         <div>
                             <div class="company-rank">#7</div>
-                            <div class="company-name">动视暴雪</div>
-                            <div class="company-name-en">Activision Blizzard</div>
+                            <div class="company-name">Activision Blizzard</div>
+                            <div class="company-name-en">Call of Duty, World of Warcraft, Overwatch</div>
                         </div>
                     </div>
-                    <div class="company-description">拥有《使命召唤》、《魔兽世界》、《守望先锋》等知名游戏。</div>
+                    <div class="company-description">Activision Blizzard delivers blockbuster shooters and MMOs with ongoing live-service support and esports communities.</div>
                     <div class="company-info">
-                        <span class="company-country">🇺🇸 美国</span>
-                        <span class="company-revenue">年收入: $7.5B</span>
+                        <span class="company-country">🇺🇸 United States</span>
+                        <span class="company-revenue">Annual revenue: $7.5B</span>
                     </div>
-                    <a href="https://www.activisionblizzard.com/" class="company-link" target="_blank">访问官网</a>
+                    <a href="https://www.activisionblizzard.com/" class="company-link" target="_blank">Visit Website</a>
                 </div>
 
                 <div class="company-card" data-category="international">
                     <div class="company-header">
-                        <img src="https://picsum.photos/80/80?random=8" alt="艺电LOGO" class="company-logo">
+                        <img src="https://picsum.photos/80/80?random=8" alt="Electronic Arts logo" class="company-logo">
                         <div>
                             <div class="company-rank">#8</div>
-                            <div class="company-name">艺电</div>
-                            <div class="company-name-en">Electronic Arts (EA)</div>
+                            <div class="company-name">Electronic Arts</div>
+                            <div class="company-name-en">FIFA, Battlefield, The Sims</div>
                         </div>
                     </div>
-                    <div class="company-description">拥有《FIFA》、《战地》、《模拟人生》等经典游戏系列。</div>
+                    <div class="company-description">EA produces live-service sports games and story franchises, spanning EA SPORTS FC, Apex Legends, The Sims, and more.</div>
                     <div class="company-info">
-                        <span class="company-country">🇺🇸 美国</span>
-                        <span class="company-revenue">年收入: $7.4B</span>
+                        <span class="company-country">🇺🇸 United States</span>
+                        <span class="company-revenue">Annual revenue: $7.4B</span>
                     </div>
-                    <a href="https://www.ea.com/" class="company-link" target="_blank">访问官网</a>
+                    <a href="https://www.ea.com/" class="company-link" target="_blank">Visit Website</a>
                 </div>
 
                 <div class="company-card" data-category="chinese">
                     <div class="company-header">
-                        <img src="https://picsum.photos/80/80?random=9" alt="完美世界LOGO" class="company-logo">
+                        <img src="https://picsum.photos/80/80?random=9" alt="Perfect World logo" class="company-logo">
                         <div>
                             <div class="company-rank">#9</div>
-                            <div class="company-name">完美世界</div>
-                            <div class="company-name-en">Perfect World</div>
+                            <div class="company-name">Perfect World</div>
+                            <div class="company-name-en">MMORPG specialist behind Perfect World and Jade Dynasty</div>
                         </div>
                     </div>
-                    <div class="company-description">中国知名游戏公司，拥有《完美世界》、《诛仙》等经典MMORPG。</div>
+                    <div class="company-description">Perfect World builds expansive MMO worlds for PC and mobile players, with strong publishing reach in Asia.</div>
                     <div class="company-info">
-                        <span class="company-country">🇨🇳 中国</span>
-                        <span class="company-revenue">年收入: $1.2B</span>
+                        <span class="company-country">🇨🇳 China</span>
+                        <span class="company-revenue">Annual revenue: $1.2B</span>
                     </div>
-                    <a href="http://www.wanmei.com/" class="company-link" target="_blank">访问官网</a>
+                    <a href="http://www.wanmei.com/" class="company-link" target="_blank">Visit Website</a>
                 </div>
 
                 <div class="company-card" data-category="international">
                     <div class="company-header">
-                        <img src="https://picsum.photos/80/80?random=10" alt="育碧LOGO" class="company-logo">
+                        <img src="https://picsum.photos/80/80?random=10" alt="Ubisoft logo" class="company-logo">
                         <div>
                             <div class="company-rank">#10</div>
-                            <div class="company-name">育碧</div>
-                            <div class="company-name-en">Ubisoft</div>
+                            <div class="company-name">Ubisoft</div>
+                            <div class="company-name-en">Assassin's Creed, Rainbow Six, Far Cry</div>
                         </div>
                     </div>
-                    <div class="company-description">法国游戏开发商，拥有《刺客信条》、《彩虹六号》、《孤岛惊魂》等系列。</div>
+                    <div class="company-description">Ubisoft develops open-world adventures and cooperative shooters with global teams across Europe, North America, and Asia.</div>
                     <div class="company-info">
-                        <span class="company-country">🇫🇷 法国</span>
-                        <span class="company-revenue">年收入: $2.3B</span>
+                        <span class="company-country">🇫🇷 France</span>
+                        <span class="company-revenue">Annual revenue: $2.3B</span>
                     </div>
-                    <a href="https://www.ubisoft.com/" class="company-link" target="_blank">访问官网</a>
+                    <a href="https://www.ubisoft.com/" class="company-link" target="_blank">Visit Website</a>
                 </div>
             </div>
         </section>
@@ -512,11 +512,11 @@
             const companies = document.querySelectorAll('.company-card');
             const tabs = document.querySelectorAll('.category-tab');
             
-            // 更新标签状态
+            // Update tab active state
             tabs.forEach(tab => tab.classList.remove('active'));
             event.target.classList.add('active');
             
-            // 过滤公司
+            // Filter companies by category
             companies.forEach(company => {
                 if (category === 'all' || company.dataset.category === category) {
                     company.style.display = 'block';
@@ -526,7 +526,7 @@
             });
         }
 
-        // 搜索功能
+        // Search functionality
         document.addEventListener('DOMContentLoaded', function() {
             const searchInput = document.getElementById('searchInput');
             searchInput.addEventListener('input', function(e) {
@@ -547,13 +547,13 @@
             });
         });
 
-        // 移动端菜单
+        // Mobile navigation toggle
         document.querySelector('.mobile-menu').addEventListener('click', function() {
             const navLinks = document.querySelector('.nav-links');
             navLinks.style.display = navLinks.style.display === 'flex' ? 'none' : 'flex';
         });
 
-        // 图片加载失败处理
+        // Handle image loading errors
         document.addEventListener('DOMContentLoaded', function() {
             const logos = document.querySelectorAll('.company-logo');
             logos.forEach(logo => {

--- a/game-development.html
+++ b/game-development.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="专业游戏开发服务 - 游戏工作室提供Unity游戏开发、Unreal游戏开发、游戏编程、游戏美术、游戏策划等全方位游戏制作服务。独立游戏制作、手游工作室、PC游戏开发。">
-    <meta name="keywords" content="游戏开发,游戏制作,独立游戏,游戏设计,Unity游戏开发,Unreal游戏开发,游戏编程,游戏美术,游戏策划,独立游戏制作,游戏开发流程,游戏开发教程,手游工作室,PC游戏开发,独立游戏开发者,国产独立游戏">
-    <meta name="author" content="游戏工作室">
+    <meta name="description" content="Professional game development services from Game Studio, covering Unity and Unreal projects, programming, art, design, and full production support for indie, mobile, and PC titles.">
+    <meta name="keywords" content="game development, game production, indie games, game design, Unity development, Unreal development, game programming, game art, game planning, indie game production, game development process, game tutorials, mobile game studio, PC game development, indie game developers">
+    <meta name="author" content="Game Studio">
     <meta name="robots" content="index, follow">
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437"
      crossorigin="anonymous"></script>
-    <title>游戏开发服务 - 专业游戏制作 | Unity游戏开发 | 独立游戏制作</title>
+    <title>Game Development Services - Unity, Unreal & Indie Production</title>
     <style>
         * {
             margin: 0;
@@ -181,91 +181,90 @@
 <body>
     <nav class="navbar">
         <div class="nav-container">
-            <a href="index.html" class="logo">游戏工作室</a>
+            <a href="index.html" class="logo">Game Studio</a>
             <ul class="nav-links">
-                <li><a href="index.html">首页</a></li>
-                <li><a href="games.html">游戏</a></li>
-                <li><a href="new-game.html">新游戏</a></li>
-                <li><a href="game-development.html">游戏开发</a></li>
-                <li><a href="company-ranking.html">公司排名</a></li>
+                <li><a href="index.html">Home</a></li>
+                <li><a href="games.html">Games</a></li>
+                <li><a href="new-game.html">New Releases</a></li>
+                <li><a href="game-development.html">Game Development</a></li>
+                <li><a href="company-ranking.html">Company Rankings</a></li>
             </ul>
         </div>
     </nav>
 
     <div class="content">
         <div class="hero-section">
-            <h1 class="hero-title">专业<span class="keyword-highlight">游戏开发</span>服务</h1>
-            <p class="hero-subtitle">专注于<span class="keyword-highlight">游戏制作</span>、<span class="keyword-highlight">独立游戏</span>设计和<span class="keyword-highlight">游戏设计</span>的全方位服务</p>
+            <h1 class="hero-title">Professional <span class="keyword-highlight">Game Development</span> Services</h1>
+            <p class="hero-subtitle">Comprehensive support for <span class="keyword-highlight">game production</span>, <span class="keyword-highlight">indie games</span>, and <span class="keyword-highlight">game design</span></p>
         </div>
 
         <div class="services-grid">
             <div class="service-card">
                 <div class="service-icon">🎮</div>
-                <h3 class="service-title">Unity游戏开发</h3>
-                <p class="service-description">使用Unity引擎进行专业的<span class="keyword-highlight">游戏开发</span>，支持<span class="keyword-highlight">手机游戏</span>、<span class="keyword-highlight">PC游戏</span>和<span class="keyword-highlight">单机游戏</span>制作。</p>
+                <h3 class="service-title">Unity Game Development</h3>
+                <p class="service-description">Professional <span class="keyword-highlight">game development</span> powered by Unity, supporting <span class="keyword-highlight">mobile games</span>, <span class="keyword-highlight">PC games</span>, and <span class="keyword-highlight">single-player</span> releases.</p>
             </div>
             
             <div class="service-card">
                 <div class="service-icon">⚡</div>
-                <h3 class="service-title">Unreal游戏开发</h3>
-                <p class="service-description">采用Unreal引擎进行高端<span class="keyword-highlight">游戏制作</span>，特别适合<span class="keyword-highlight">网络游戏</span>和大型<span class="keyword-highlight">独立游戏</span>项目。</p>
+                <h3 class="service-title">Unreal Game Development</h3>
+                <p class="service-description">High-end <span class="keyword-highlight">game production</span> with Unreal Engine, ideal for <span class="keyword-highlight">online games</span> and large-scale <span class="keyword-highlight">indie</span> projects.</p>
             </div>
             
             <div class="service-card">
                 <div class="service-icon">💻</div>
-                <h3 class="service-title">游戏编程</h3>
-                <p class="service-description">专业的<span class="keyword-highlight">游戏编程</span>服务，涵盖各种<span class="keyword-highlight">游戏引擎</span>和平台，确保游戏性能和稳定性。</p>
+                <h3 class="service-title">Game Programming</h3>
+                <p class="service-description">Specialized <span class="keyword-highlight">game programming</span> across major <span class="keyword-highlight">game engines</span> and platforms to guarantee performance and stability.</p>
             </div>
             
             <div class="service-card">
                 <div class="service-icon">🎨</div>
-                <h3 class="service-title">游戏美术</h3>
-                <p class="service-description">专业的<span class="keyword-highlight">游戏美术</span>设计，为<span class="keyword-highlight">角色扮演游戏(RPG)</strong>、<span class="keyword-highlight">策略游戏</span>等提供精美视觉设计。</p>
+                <h3 class="service-title">Game Art</h3>
+                <p class="service-description">High-quality <span class="keyword-highlight">game art</span> for <span class="keyword-highlight">role-playing (RPG)</span>, <span class="keyword-highlight">strategy</span>, and other experiences with memorable visuals.</p>
             </div>
             
             <div class="service-card">
                 <div class="service-icon">📋</div>
-                <h3 class="service-title">游戏策划</h3>
-                <p class="service-description">专业的<span class="keyword-highlight">游戏策划</span>服务，为<span class="keyword-highlight">动作游戏</span>、<span class="keyword-highlight">冒险游戏</span>和<span class="keyword-highlight">休闲游戏</span>提供完整设计方案。</p>
+                <h3 class="service-title">Game Design & Planning</h3>
+                <p class="service-description">Complete <span class="keyword-highlight">game design</span> solutions for <span class="keyword-highlight">action</span>, <span class="keyword-highlight">adventure</span>, and <span class="keyword-highlight">casual</span> games.</p>
             </div>
             
             <div class="service-card">
                 <div class="service-icon">🏢</div>
-                <h3 class="service-title">手游工作室</h3>
-                <p class="service-description">专业的<span class="keyword-highlight">手游工作室</span>服务，专注于<span class="keyword-highlight">手机游戏</span>开发和<span class="keyword-highlight">免费游戏</span>制作。</p>
+                <h3 class="service-title">Mobile Game Studio</h3>
+                <p class="service-description">Dedicated <span class="keyword-highlight">mobile game</span> expertise focused on <span class="keyword-highlight">smartphone</span> development and engaging <span class="keyword-highlight">free-to-play</span> content.</p>
             </div>
         </div>
 
         <div class="seo-content">
-            <h2 class="seo-title">🎯 游戏开发服务详情</h2>
+            <h2 class="seo-title">🎯 Game Development Service Overview</h2>
             <p class="seo-text">
-                作为专业的<span class="keyword-highlight">游戏开发公司</span>，我们提供完整的<span class="keyword-highlight">游戏开发流程</span>服务。从<span class="keyword-highlight">独立游戏制作</span>到大型商业项目，我们的<span class="keyword-highlight">游戏制作人</span>团队都能胜任。
+                As a specialized <span class="keyword-highlight">game development studio</span>, we provide an end-to-end <span class="keyword-highlight">production pipeline</span>. From <span class="keyword-highlight">indie concepts</span> to large commercial launches, our experienced producers guide every milestone.
             </p>
-            
+
             <p class="seo-text">
-                我们的<span class="keyword-highlight">游戏开发</span>服务涵盖<span class="keyword-highlight">PC游戏开发</span>、<span class="keyword-highlight">手机游戏</span>开发、<span class="keyword-highlight">单机游戏</span>制作和<span class="keyword-highlight">网络游戏</span>开发。无论是<span class="keyword-highlight">角色扮演游戏(RPG)</span>、<span class="keyword-highlight">策略游戏</span>、<span class="keyword-highlight">动作游戏</span>还是<span class="keyword-highlight">冒险游戏</span>，我们都有丰富的开发经验。
+                Our <span class="keyword-highlight">development services</span> span <span class="keyword-highlight">PC</span>, <span class="keyword-highlight">mobile</span>, <span class="keyword-highlight">single-player</span>, and <span class="keyword-highlight">online</span> games. Whether you need an <span class="keyword-highlight">RPG</span>, <span class="keyword-highlight">strategy</span>, <span class="keyword-highlight">action</span>, or <span class="keyword-highlight">adventure</span> title, we have the hands-on experience to deliver.
             </p>
-            
+
             <p class="seo-text">
-                我们使用先进的<span class="keyword-highlight">游戏引擎</span>技术，包括<span class="keyword-highlight">Unity游戏开发</span>和<span class="keyword-highlight">Unreal游戏开发</span>。我们的<span class="keyword-highlight">游戏编程</span>团队精通各种编程语言和开发工具，确保游戏的高质量和稳定性。
+                We build with leading <span class="keyword-highlight">game engines</span> such as <span class="keyword-highlight">Unity</span> and <span class="keyword-highlight">Unreal Engine</span>. Our <span class="keyword-highlight">programming team</span> masters multiple languages and tools to keep projects optimized and stable.
             </p>
-            
+
             <p class="seo-text">
-                作为<span class="keyword-highlight">独立游戏开发者</span>的合作伙伴，我们支持<span class="keyword-highlight">国产独立游戏</span>的发展。我们提供<span class="keyword-highlight">游戏开发教程</span>和技术支持，帮助更多开发者实现游戏梦想。
+                Supporting <span class="keyword-highlight">indie developers</span> is core to our mission. We share <span class="keyword-highlight">tutorials</span>, technical mentorship, and publishing guidance to help creative teams bring their ideas to life.
             </p>
-            
+
             <p class="seo-text">
-                我们的<span class="keyword-highlight">游戏美术</span>团队擅长为各种类型的游戏提供视觉设计，包括角色设计、场景设计、UI设计等。我们的<span class="keyword-highlight">游戏策划</span>团队负责游戏的整体规划和设计，确保游戏的可玩性和趣味性。
+                The <span class="keyword-highlight">art team</span> crafts character, environment, and UI assets tailored to each genre, while our <span class="keyword-highlight">designers</span> ensure gameplay depth and accessibility.
             </p>
-            
+
             <p class="seo-text">
-                如果您正在寻找专业的<span class="keyword-highlight">游戏工作室</span>进行<span class="keyword-highlight">游戏开发</span>或<span class="keyword-highlight">游戏制作</span>，欢迎联系我们。我们提供<span class="keyword-highlight">游戏工作室招聘</span>信息，欢迎优秀的<span class="keyword-highlight">独立游戏开发者</span>加入我们的团队。
-            </p>
+                Looking for a trusted <span class="keyword-highlight">game studio partner</span>? Reach out to collaborate on <span class="keyword-highlight">development</span> or <span class="keyword-highlight">production</span>, or explore our <span class="keyword-highlight">career opportunities</span> for talented creators.</p>
         </div>
     </div>
 
     <script>
-        // 添加页面交互效果
+        // Add simple interaction effects
         document.addEventListener('DOMContentLoaded', function() {
             const serviceCards = document.querySelectorAll('.service-card');
             

--- a/gamedistribution-embed-urls.html
+++ b/gamedistribution-embed-urls.html
@@ -126,7 +126,7 @@
                     <iframe class="game-iframe" src="https://html5.gamedistribution.com/e1e32230bdf040d69f4e367015e1c527/" allowfullscreen></iframe>
                 </div>
                 <div class="game-card">
-                    <div class="game-title">示例：自定义游戏</div>
+                    <div class="game-title">Example: Custom Game</div>
                     <a class="game-link" href="https://html5.gamedistribution.com/10f0beef65fe40ccae23194fd95782a8/" target="_blank">https://html5.gamedistribution.com/10f0beef65fe40ccae23194fd95782a8/</a>
                     <iframe class="game-iframe" src="https://html5.gamedistribution.com/10f0beef65fe40ccae23194fd95782a8/" allowfullscreen></iframe>
                 </div>

--- a/games.html
+++ b/games.html
@@ -231,7 +231,7 @@
                     <iframe class="game-iframe" src="https://html5.gamedistribution.com/e1e32230bdf040d69f4e367015e1c527/" allowfullscreen></iframe>
                 </div>
                 <div class="game-card">
-                    <div class="game-title">示例：自定义游戏</div>
+                    <div class="game-title">Example: Custom Game</div>
                     <a class="game-link" href="https://html5.gamedistribution.com/10f0beef65fe40ccae23194fd95782a8/" target="_blank">https://html5.gamedistribution.com/10f0beef65fe40ccae23194fd95782a8/</a>
                     <iframe class="game-iframe" src="https://html5.gamedistribution.com/10f0beef65fe40ccae23194fd95782a8/" allowfullscreen></iframe>
                 </div>

--- a/index - 副本.html
+++ b/index - 副本.html
@@ -453,7 +453,7 @@
                     <iframe class="game-iframe" src="https://html5.gamedistribution.com/e1e32230bdf040d69f4e367015e1c527/" allowfullscreen></iframe>
                 </div>
                 <div class="game-card">
-                    <div class="game-title">示例：自定义游戏</div>
+                    <div class="game-title">Example: Custom Game</div>
                     <a class="game-link" href="https://html5.gamedistribution.com/10f0beef65fe40ccae23194fd95782a8/" target="_blank">https://html5.gamedistribution.com/10f0beef65fe40ccae23194fd95782a8/</a>
                     <iframe class="game-iframe" src="https://html5.gamedistribution.com/10f0beef65fe40ccae23194fd95782a8/" allowfullscreen></iframe>
                 </div>

--- a/index.html
+++ b/index.html
@@ -1,16 +1,16 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="en">
 <head>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437"
      crossorigin="anonymous"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="专业游戏工作室 - 专注于游戏开发、游戏制作、独立游戏设计。提供手机游戏、PC游戏、单机游戏、网络游戏开发服务。最新游戏资讯、热门游戏推荐、游戏攻略分享。">
-    <meta name="keywords" content="游戏工作室,游戏开发,游戏制作,独立游戏,游戏设计,手机游戏,PC游戏,单机游戏,网络游戏,RPG游戏,策略游戏,动作游戏,冒险游戏,休闲游戏,免费游戏,最新游戏,热门游戏,游戏推荐,游戏攻略,游戏评测,游戏资讯,游戏新闻,游戏引擎,Unity游戏开发,Unreal游戏开发,游戏编程,游戏美术,游戏策划">
-    <meta name="author" content="游戏工作室">
+    <meta name="description" content="Game Studio - Professional game development, publishing, and design services. Discover mobile, PC, and web games alongside the latest news, featured releases, and gameplay tips.">
+    <meta name="keywords" content="game studio, game development, game production, indie games, game design, mobile games, PC games, single-player games, online games, RPG, strategy games, action games, adventure games, casual games, free games, latest games, popular games, game recommendations, game guides, game reviews, game news, game engine, Unity development, Unreal development, game programming, game art, game planning">
+    <meta name="author" content="Game Studio">
     <meta name="robots" content="index, follow">
     <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml">
-    <title>游戏工作室 - 专业游戏开发制作 | 独立游戏设计 | 手机游戏PC游戏开发</title>
+    <title>Game Studio - Professional Game Development & Indie Game Design</title>
     <style>
         * {
             margin: 0;
@@ -120,7 +120,7 @@
             font-size: 1rem;
         }
 
-        /* 社交媒体分享按钮样式 */
+        /* Social media sharing styles */
         .share-section {
             background: rgba(255, 255, 255, 0.95);
             border-radius: 20px;
@@ -495,11 +495,11 @@
         <div class="nav-container">
             <a href="#" class="logo">game studio</a>
             <ul class="nav-links">
-                <li><a href="index.html">首页</a></li>
-                <li><a href="games.html">游戏</a></li>
-                <li><a href="new-game.html">新游戏</a></li>
-                <li><a href="game-development.html">游戏开发</a></li>
-                <li><a href="company-ranking.html">公司排名</a></li>
+                <li><a href="index.html">Home</a></li>
+                <li><a href="games.html">Games</a></li>
+                <li><a href="new-game.html">New Releases</a></li>
+                <li><a href="game-development.html">Game Development</a></li>
+                <li><a href="company-ranking.html">Company Rankings</a></li>
             </ul>
             <div class="search-box">
                 <input type="text" placeholder="Search games..." id="searchInput">
@@ -653,9 +653,9 @@
             </div>
         </section>
 
-        <!-- 社交媒体分享区域 -->
+        <!-- Social media share area -->
         <section class="share-section">
-            <h2 class="share-title">🌐 分享到社交媒体</h2>
+            <h2 class="share-title">🌐 Share on Social Media</h2>
             <div class="share-buttons">
                 <a href="#" class="share-btn facebook" onclick="shareToFacebook()">
                     <span class="share-icon">📘</span>
@@ -691,27 +691,27 @@
                 </a>
                 <button class="share-btn copy" onclick="copyPageLink()">
                     <span class="share-icon">📋</span>
-                    复制链接
+                    Copy Link
                 </button>
             </div>
         </section>
 
-        <!-- SEO优化内容区域 -->
+        <!-- SEO content area -->
         <section class="section">
-            <h2 class="section-title">🎮 游戏工作室 - 专业游戏开发制作服务</h2>
+            <h2 class="section-title">🎮 Game Studio - Professional Game Development Services</h2>
             <div style="line-height: 1.8; color: #555; margin-bottom: 2rem;">
-                <p><strong>游戏工作室</strong>专注于<strong>游戏开发</strong>、<strong>游戏制作</strong>和<strong>独立游戏</strong>设计。我们提供专业的<strong>游戏设计</strong>服务，涵盖<strong>手机游戏</strong>、<strong>PC游戏</strong>、<strong>单机游戏</strong>和<strong>网络游戏</strong>开发。</p>
-                
-                <p>我们的<strong>游戏开发</strong>团队擅长制作各种类型的游戏，包括<strong>角色扮演游戏(RPG)</strong>、<strong>策略游戏</strong>、<strong>动作游戏</strong>、<strong>冒险游戏</strong>和<strong>休闲游戏</strong>。所有游戏均为<strong>免费游戏</strong>，让玩家享受优质的游戏体验。</p>
-                
-                <p>作为专业的<strong>游戏开发公司</strong>，我们使用先进的<strong>游戏引擎</strong>技术，包括<strong>Unity游戏开发</strong>和<strong>Unreal游戏开发</strong>。我们的<strong>游戏编程</strong>、<strong>游戏美术</strong>和<strong>游戏策划</strong>团队致力于为玩家带来<strong>最新游戏</strong>和<strong>热门游戏</strong>。</p>
-                
-                <p>我们提供<strong>游戏推荐</strong>、<strong>游戏攻略</strong>、<strong>游戏评测</strong>和<strong>游戏资讯</strong>，让玩家及时了解<strong>游戏新闻</strong>和行业动态。无论是<strong>独立游戏制作</strong>还是大型项目，我们都能提供完整的<strong>游戏开发流程</strong>服务。</p>
+                <p><strong>Game Studio</strong> specializes in <strong>game development</strong>, <strong>production</strong>, and <strong>indie game</strong> design. We deliver end-to-end <strong>game design</strong> services for <strong>mobile</strong>, <strong>PC</strong>, <strong>single-player</strong>, and <strong>online</strong> experiences.</p>
+
+                <p>Our <strong>development team</strong> builds a wide range of genres, including <strong>role-playing (RPG)</strong>, <strong>strategy</strong>, <strong>action</strong>, <strong>adventure</strong>, and <strong>casual</strong> games. Every project focuses on polished gameplay so players can enjoy premium experiences for free.</p>
+
+                <p>As a dedicated <strong>game development company</strong>, we use modern <strong>game engines</strong> such as <strong>Unity</strong> and <strong>Unreal Engine</strong>. Our <strong>programmers</strong>, <strong>artists</strong>, and <strong>designers</strong> collaborate to ship the <strong>latest</strong> and most <strong>popular games</strong>.</p>
+
+                <p>We also share <strong>game recommendations</strong>, <strong>guides</strong>, <strong>reviews</strong>, and <strong>industry news</strong> so fans stay informed about trends. From <strong>indie productions</strong> to large-scale launches, we support a complete <strong>game development pipeline</strong>.</p>
             </div>
         </section>
 
         <section class="section">
-            <h2 class="section-title">🆕 最新游戏</h2>
+            <h2 class="section-title">🆕 Latest Games</h2>
             <div class="games-grid" id="newGamesGrid" style="grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: 1.5rem;">
                 <div class="game-card">
                     <div class="game-title">Wacky Flip</div>
@@ -742,7 +742,7 @@
                     <iframe data-src="https://html5.gamedistribution.com/e1e32230bdf040d69f4e367015e1c527/" style="width: 100%; height: 200px; border: none; border-radius: 10px; margin-top: 0.5rem; background: #e0e0e0;" allowfullscreen allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"></iframe>
                 </div>
                 <div class="game-card">
-                    <div class="game-title">示例：自定义游戏</div>
+                    <div class="game-title">Example: Custom Game</div>
                     <iframe data-src="https://html5.gamedistribution.com/10f0beef65fe40ccae23194fd95782a8/" style="width: 100%; height: 200px; border: none; border-radius: 10px; margin-top: 0.5rem; background: #e0e0e0;" allowfullscreen allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"></iframe>
                 </div>
                 <div class="game-card">
@@ -779,12 +779,12 @@
         <section class="section">
             <h2 class="section-title">🏆 TOP</h2>
             <div class="games-grid" id="topGamesGrid" style="grid-template-columns: repeat(6, 1fr); gap: 1rem;">
-                <!-- 已删除指定的游戏卡片 -->
+                <!-- Removed the requested game card -->
             </div>
         </section>
 
         <section class="section">
-            <h2 class="section-title">🧩 Brain Teasers - 益智游戏</h2>
+            <h2 class="section-title">🧩 Brain Teasers - Puzzle Games</h2>
             <div class="games-grid" id="brainTeasersGrid" style="grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: 1.5rem;">
                 <div class="game-card">
                     <div class="game-title">Memoji</div>
@@ -932,14 +932,14 @@
                 card.classList.add('popular-game-card');
                 card.setAttribute('role', 'button');
                 card.setAttribute('tabindex', '0');
-                card.setAttribute('aria-label', '点击加载游戏内容');
+                card.setAttribute('aria-label', 'Click to load the game content');
                 iframe.classList.add('game-iframe');
 
                 const placeholder = document.createElement('div');
                 placeholder.className = 'game-placeholder';
                 placeholder.innerHTML = `
-                    <img src="${placeholderImage}" alt="点击开始游戏" loading="lazy">
-                    <p>点击卡片快速加载游戏</p>
+                    <img src="${placeholderImage}" alt="Click to start the game" loading="lazy">
+                    <p>Click the card to load the game instantly</p>
                 `;
                 card.insertBefore(placeholder, iframe);
 
@@ -1022,7 +1022,7 @@
             navLinks.style.display = navLinks.style.display === 'flex' ? 'none' : 'flex';
         });
 
-        // 社交媒体分享功能
+        // Social media share helpers
         function shareToFacebook() {
             const url = encodeURIComponent(window.location.href);
             const title = encodeURIComponent(document.title);
@@ -1084,19 +1084,19 @@
         function copyPageLink() {
             const url = window.location.href;
             navigator.clipboard.writeText(url).then(function() {
-                // 显示复制成功提示
+                // Show a success message
                 const copyBtn = document.querySelector('.share-btn.copy');
                 const originalText = copyBtn.innerHTML;
-                copyBtn.innerHTML = '<span class="share-icon">✅</span>已复制';
+                copyBtn.innerHTML = '<span class="share-icon">✅</span>Copied';
                 copyBtn.style.background = 'linear-gradient(45deg, #22c55e, #16a34a)';
-                
+
                 setTimeout(() => {
                     copyBtn.innerHTML = originalText;
                     copyBtn.style.background = 'linear-gradient(45deg, #6b7280, #9ca3af)';
                 }, 2000);
             }).catch(function(err) {
-                console.error('复制失败:', err);
-                alert('复制失败，请手动复制链接：' + url);
+                console.error('Copy failed:', err);
+                alert('Copy failed. Please copy the link manually: ' + url);
             });
         }
     </script>

--- a/new-game.html
+++ b/new-game.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="最新游戏发布 - 游戏工作室为您带来最新的手机游戏、PC游戏、独立游戏。包含动作游戏、策略游戏、RPG游戏等多种游戏类型。免费游戏下载，游戏攻略分享。">
-    <meta name="keywords" content="最新游戏,新游戏,手机游戏,PC游戏,独立游戏,动作游戏,策略游戏,RPG游戏,冒险游戏,休闲游戏,免费游戏,游戏下载,游戏攻略">
-    <meta name="author" content="游戏工作室">
+    <meta name="description" content="Discover the newest games from Game Studio, including mobile, PC, and indie releases. Explore action, strategy, RPG, adventure, and casual titles with free downloads and helpful guides.">
+    <meta name="keywords" content="new games, latest games, mobile games, PC games, indie games, action games, strategy games, RPG, adventure games, casual games, free games, game downloads, game guides">
+    <meta name="author" content="Game Studio">
     <meta name="robots" content="index, follow">
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437"
      crossorigin="anonymous"></script>
-    <title>最新游戏 - 游戏工作室 | 新游戏发布 | 手机游戏PC游戏下载</title>
+    <title>Latest Games - Game Studio | New Releases & Downloads</title>
     <style>
         * {
             margin: 0;
@@ -104,7 +104,7 @@
             text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
         }
 
-        /* 游戏卡片样式 */
+        /* Game card styles */
         .game-card {
             background: rgba(255, 255, 255, 0.95);
             border-radius: 15px;
@@ -196,7 +196,7 @@
             text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
         }
 
-        /* 响应式设计 */
+        /* Responsive design */
         @media (max-width: 768px) {
             .nav-links {
                 display: none;
@@ -236,7 +236,7 @@
             }
         }
 
-        /* 社交媒体分享按钮样式 */
+        /* Social media sharing styles */
         .share-section {
             background: rgba(255, 255, 255, 0.95);
             border-radius: 20px;
@@ -338,29 +338,29 @@
     </style>
 </head>
 <body>
-    <!-- 导航栏 -->
+    <!-- Navigation bar -->
     <nav class="navbar">
         <div class="nav-container">
-            <a href="index.html" class="logo">游戏工作室</a>
+            <a href="index.html" class="logo">Game Studio</a>
             <ul class="nav-links">
-                <li><a href="index.html">首页</a></li>
-                <li><a href="games.html">游戏</a></li>
-                <li><a href="new-game.html">新游戏</a></li>
-                <li><a href="top-games.html">热门游戏</a></li>
+                <li><a href="index.html">Home</a></li>
+                <li><a href="games.html">Games</a></li>
+                <li><a href="new-game.html">New Releases</a></li>
+                <li><a href="top-games.html">Top Games</a></li>
             </ul>
             <div class="search-box">
-                <input type="text" placeholder="搜索游戏...">
+                <input type="text" placeholder="Search games...">
             </div>
         </div>
     </nav>
 
-    <!-- 主要内容 -->
+    <!-- Main content -->
     <div class="content">
-        <h1 class="page-title">新游戏</h1>
+        <h1 class="page-title">New Games</h1>
 
-        <!-- 社交媒体分享区域 -->
+        <!-- Social share area -->
         <div class="share-section">
-            <h2 class="share-title">🌐 分享到社交媒体</h2>
+            <h2 class="share-title">🌐 Share on Social Media</h2>
             <div class="share-buttons">
                 <a href="#" class="share-btn facebook" onclick="shareToFacebook()">
                     <span class="share-icon">📘</span>
@@ -396,17 +396,17 @@
                 </a>
                 <button class="share-btn copy" onclick="copyPageLink()">
                     <span class="share-icon">📋</span>
-                    复制链接
+                    Copy Link
                 </button>
             </div>
         </div>
 
-        <!-- 多人游戏板块 -->
+        <!-- Multiplayer section -->
         <div class="game-card">
             <div class="card-header">
-                <h2 class="card-title">多人游戏</h2>
+                <h2 class="card-title">Multiplayer Games</h2>
                 <a href="#" class="more-link">
-                    更多的
+                    See more
                     <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 320 512" height="10px" width="10px" xmlns="http://www.w3.org/2000/svg">
                         <path d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"></path>
                     </svg>
@@ -414,122 +414,122 @@
             </div>
             <div class="games-grid">
                 <div class="game-item">
-                    <img alt="在线攻击" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=11">
+                    <img alt="Online Assault" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=11">
                     <div class="game-overlay">
-                        <h5 class="game-title">在线攻击</h5>
+                        <h5 class="game-title">Online Assault</h5>
                     </div>
                 </div>
                 <div class="game-item">
-                    <img alt="真实台球 3D" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=12">
+                    <img alt="Real Billiards 3D" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=12">
                     <div class="game-overlay">
-                        <h5 class="game-title">真实台球 3D</h5>
+                        <h5 class="game-title">Real Billiards 3D</h5>
                     </div>
                 </div>
                 <div class="game-item">
-                    <img alt="终极特技车挑战" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=13">
+                    <img alt="Ultimate Stunt Car Challenge" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=13">
                     <div class="game-overlay">
-                        <h5 class="game-title">终极特技车挑战</h5>
+                        <h5 class="game-title">Ultimate Stunt Car Challenge</h5>
                     </div>
                 </div>
                 <div class="game-item">
-                    <img alt="动物园缩放形状" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=14">
+                    <img alt="Zoo Zoom Shapes" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=14">
                     <div class="game-overlay">
-                        <h5 class="game-title">动物园缩放形状</h5>
+                        <h5 class="game-title">Zoo Zoom Shapes</h5>
                     </div>
                 </div>
                 <div class="game-item">
-                    <img alt="翡翠岛纸牌" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=15">
+                    <img alt="Emerald Isle Solitaire" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=15">
                     <div class="game-overlay">
-                        <h5 class="game-title">翡翠岛纸牌</h5>
+                        <h5 class="game-title">Emerald Isle Solitaire</h5>
                     </div>
                 </div>
                 <div class="game-item">
-                    <img alt="魔法纸牌" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=16">
+                    <img alt="Magic Solitaire" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=16">
                     <div class="game-overlay">
-                        <h5 class="game-title">魔法纸牌</h5>
+                        <h5 class="game-title">Magic Solitaire</h5>
                     </div>
                 </div>
                 <div class="game-item">
-                    <img alt="儿童几何" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=17">
+                    <img alt="Kids Geometry" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=17">
                     <div class="game-overlay">
-                        <h5 class="game-title">儿童几何</h5>
+                        <h5 class="game-title">Kids Geometry</h5>
                     </div>
                 </div>
                 <div class="game-item">
-                    <img alt="蔬菜朋友游戏" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=18">
+                    <img alt="Vegetable Friends" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=18">
                     <div class="game-overlay">
-                        <h5 class="game-title">蔬菜朋友游戏</h5>
+                        <h5 class="game-title">Vegetable Friends</h5>
                     </div>
                 </div>
                 <div class="game-item">
-                    <img alt="遇见鸟儿" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=19">
+                    <img alt="Meet the Birds" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=19">
                     <div class="game-overlay">
-                        <h5 class="game-title">遇见鸟儿</h5>
+                        <h5 class="game-title">Meet the Birds</h5>
                     </div>
                 </div>
                 <div class="game-item">
-                    <img alt="晚安我的宝贝" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=20">
+                    <img alt="Good Night My Baby" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=20">
                     <div class="game-overlay">
-                        <h5 class="game-title">晚安我的宝贝</h5>
+                        <h5 class="game-title">Good Night My Baby</h5>
                     </div>
                 </div>
                 <div class="game-item">
-                    <img alt="色彩路径输入输出" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=21">
+                    <img alt="Color Path In & Out" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=21">
                     <div class="game-overlay">
-                        <h5 class="game-title">色彩路径输入输出</h5>
+                        <h5 class="game-title">Color Path In & Out</h5>
                     </div>
                 </div>
                 <div class="game-item">
-                    <img alt="台球冠军" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=22">
+                    <img alt="Billiards Champion" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=22">
                     <div class="game-overlay">
-                        <h5 class="game-title">台球冠军</h5>
+                        <h5 class="game-title">Billiards Champion</h5>
                     </div>
                 </div>
                 <div class="game-item">
-                    <img alt="丛林之战" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=23">
+                    <img alt="Jungle Battle" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=23">
                     <div class="game-overlay">
-                        <h5 class="game-title">丛林之战</h5>
+                        <h5 class="game-title">Jungle Battle</h5>
                     </div>
                 </div>
                 <div class="game-item">
-                    <img alt="棋盘国王棋盘骰子" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=24">
+                    <img alt="Board King Dice" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=24">
                     <div class="game-overlay">
-                        <h5 class="game-title">棋盘国王棋盘骰子</h5>
+                        <h5 class="game-title">Board King Dice</h5>
                     </div>
                 </div>
                 <div class="game-item">
-                    <img alt="德州扑克游戏" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=25">
+                    <img alt="Texas Hold'em Poker" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=25">
                     <div class="game-overlay">
-                        <h5 class="game-title">德州扑克游戏</h5>
+                        <h5 class="game-title">Texas Hold'em Poker</h5>
                     </div>
                 </div>
                 <div class="game-item">
-                    <img alt="七张牌游戏" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=26">
+                    <img alt="Seven Card Showdown" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=26">
                     <div class="game-overlay">
-                        <h5 class="game-title">七张牌游戏</h5>
+                        <h5 class="game-title">Seven Card Showdown</h5>
                     </div>
                 </div>
                 <div class="game-item">
-                    <img alt="气球竞赛3D" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=27">
+                    <img alt="Balloon Race 3D" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=27">
                     <div class="game-overlay">
-                        <h5 class="game-title">气球竞赛3D</h5>
+                        <h5 class="game-title">Balloon Race 3D</h5>
                     </div>
                 </div>
                 <div class="game-item">
-                    <img alt="SEOTDA 纸牌游戏" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=28">
+                    <img alt="SEOTDA Card Game" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=28">
                     <div class="game-overlay">
-                        <h5 class="game-title">SEOTDA 纸牌游戏</h5>
+                        <h5 class="game-title">SEOTDA Card Game</h5>
                     </div>
                 </div>
             </div>
         </div>
 
-        <!-- 可以在这里添加更多游戏板块 -->
+        <!-- Additional sections can be added here -->
         <div class="game-card">
             <div class="card-header">
-                <h2 class="card-title">热门新游戏</h2>
+                <h2 class="card-title">Trending New Games</h2>
                 <a href="#" class="more-link">
-                    更多的
+                    See more
                     <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 320 512" height="10px" width="10px" xmlns="http://www.w3.org/2000/svg">
                         <path d="M310.6 233.4c12.5 12.5 12.5 32.8 0 45.3l-192 192c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3L242.7 256 73.4 86.6c-12.5-12.5-12.5-32.8 0-45.3s32.8-12.5 45.3 0l192 192z"></path>
                     </svg>
@@ -537,27 +537,27 @@
             </div>
             <div class="games-grid">
                 <div class="game-item">
-                    <img alt="赛车竞速" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=31">
+                    <img alt="Racing Rush" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=31">
                     <div class="game-overlay">
-                        <h5 class="game-title">赛车竞速</h5>
+                        <h5 class="game-title">Racing Rush</h5>
                     </div>
                 </div>
                 <div class="game-item">
-                    <img alt="益智解谜" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=32">
+                    <img alt="Puzzle Quest" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=32">
                     <div class="game-overlay">
-                        <h5 class="game-title">益智解谜</h5>
+                        <h5 class="game-title">Puzzle Quest</h5>
                     </div>
                 </div>
                 <div class="game-item">
-                    <img alt="动作冒险" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=33">
+                    <img alt="Action Adventure" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=33">
                     <div class="game-overlay">
-                        <h5 class="game-title">动作冒险</h5>
+                        <h5 class="game-title">Action Adventure</h5>
                     </div>
                 </div>
                 <div class="game-item">
-                    <img alt="策略游戏" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=34">
+                    <img alt="Strategy Challenge" loading="lazy" width="200" height="200" class="game-image" src="https://picsum.photos/200/200?random=34">
                     <div class="game-overlay">
-                        <h5 class="game-title">策略游戏</h5>
+                        <h5 class="game-title">Strategy Challenge</h5>
                     </div>
                 </div>
             </div>
@@ -565,7 +565,7 @@
     </div>
 
     <script>
-        // 简单的搜索功能
+        // Simple search feature
         document.querySelector('.search-box input').addEventListener('input', function(e) {
             const searchTerm = e.target.value.toLowerCase();
             const gameItems = document.querySelectorAll('.game-item');
@@ -580,16 +580,16 @@
             });
         });
 
-        // 游戏点击事件
+        // Game click handler
         document.querySelectorAll('.game-item').forEach(item => {
             item.addEventListener('click', function() {
                 const gameTitle = this.querySelector('.game-title').textContent;
-                alert(`您点击了游戏: ${gameTitle}`);
-                // 这里可以添加跳转到游戏详情页的逻辑
+                alert(`You clicked on: ${gameTitle}`);
+                // Add navigation to the game details page here if needed
             });
         });
 
-        // 图片加载失败处理
+        // Handle broken images
         document.addEventListener('DOMContentLoaded', function() {
             const gameImages = document.querySelectorAll('.game-image');
             gameImages.forEach(img => {
@@ -601,12 +601,12 @@
                     this.style.color = 'white';
                     this.style.fontSize = '1.2rem';
                     this.style.fontWeight = 'bold';
-                    this.textContent = this.alt || '游戏图片';
+                    this.textContent = this.alt || 'Game image';
                 });
             });
         });
 
-        // 社交媒体分享功能
+        // Social media share helpers
         function shareToFacebook() {
             const url = encodeURIComponent(window.location.href);
             const title = encodeURIComponent(document.title);
@@ -668,10 +668,10 @@
         function copyPageLink() {
             const url = window.location.href;
             navigator.clipboard.writeText(url).then(function() {
-                // 显示复制成功提示
+                // Show a success message
                 const copyBtn = document.querySelector('.share-btn.copy');
                 const originalText = copyBtn.innerHTML;
-                copyBtn.innerHTML = '<span class="share-icon">✅</span>已复制';
+                copyBtn.innerHTML = '<span class="share-icon">✅</span>Copied';
                 copyBtn.style.background = 'linear-gradient(45deg, #22c55e, #16a34a)';
                 
                 setTimeout(() => {
@@ -679,8 +679,8 @@
                     copyBtn.style.background = 'linear-gradient(45deg, #6b7280, #9ca3af)';
                 }, 2000);
             }).catch(function(err) {
-                console.error('复制失败:', err);
-                alert('复制失败，请手动复制链接：' + url);
+                console.error('Copy failed:', err);
+                alert('Copy failed. Please copy the link manually: ' + url);
             });
         }
     </script>

--- a/share-component.html
+++ b/share-component.html
@@ -1,9 +1,9 @@
-<!-- 社交媒体分享组件 -->
-<!-- 使用方法：将此代码复制到任何页面的适当位置 -->
+<!-- Social media sharing component -->
+<!-- Usage: copy this snippet into any page where sharing is needed -->
 
-<!-- 分享区域HTML -->
+<!-- Share area HTML -->
 <div class="share-section">
-    <h2 class="share-title">🌐 分享到社交媒体</h2>
+    <h2 class="share-title">🌐 Share on Social Media</h2>
     <div class="share-buttons">
         <a href="#" class="share-btn facebook" onclick="shareToFacebook()">
             <span class="share-icon">📘</span>
@@ -39,12 +39,12 @@
         </a>
         <button class="share-btn copy" onclick="copyPageLink()">
             <span class="share-icon">📋</span>
-            复制链接
+            Copy Link
         </button>
     </div>
 </div>
 
-<!-- 分享按钮CSS样式 -->
+<!-- Share button CSS styles -->
 <style>
     .share-section {
         background: rgba(255, 255, 255, 0.95);
@@ -146,9 +146,9 @@
     }
 </style>
 
-<!-- 分享功能JavaScript -->
+<!-- Sharing JavaScript helpers -->
 <script>
-    // 社交媒体分享功能
+    // Social media share helpers
     function shareToFacebook() {
         const url = encodeURIComponent(window.location.href);
         const title = encodeURIComponent(document.title);
@@ -209,21 +209,21 @@
 
     function copyPageLink() {
         const url = window.location.href;
-        navigator.clipboard.writeText(url).then(function() {
-            // 显示复制成功提示
-            const copyBtn = document.querySelector('.share-btn.copy');
-            const originalText = copyBtn.innerHTML;
-            copyBtn.innerHTML = '<span class="share-icon">✅</span>已复制';
-            copyBtn.style.background = 'linear-gradient(45deg, #22c55e, #16a34a)';
+            navigator.clipboard.writeText(url).then(function() {
+                // Show a success message
+                const copyBtn = document.querySelector('.share-btn.copy');
+                const originalText = copyBtn.innerHTML;
+                copyBtn.innerHTML = '<span class="share-icon">✅</span>Copied';
+                copyBtn.style.background = 'linear-gradient(45deg, #22c55e, #16a34a)';
             
             setTimeout(() => {
                 copyBtn.innerHTML = originalText;
                 copyBtn.style.background = 'linear-gradient(45deg, #6b7280, #9ca3af)';
             }, 2000);
-        }).catch(function(err) {
-            console.error('复制失败:', err);
-            alert('复制失败，请手动复制链接：' + url);
-        });
-    }
+            }).catch(function(err) {
+                console.error('Copy failed:', err);
+                alert('Copy failed. Please copy the link manually: ' + url);
+            });
+        }
 </script>
 

--- a/top-games.html
+++ b/top-games.html
@@ -183,7 +183,7 @@
     </div>
 
     <script>
-        // 添加点击事件 - 打开游戏链接
+        // Add click handlers to open game links
         document.querySelectorAll('.game-card').forEach(card => {
             card.addEventListener('click', () => {
                 const gameUrl = card.getAttribute('data-url');
@@ -193,7 +193,7 @@
             });
         });
 
-        // 添加随机颜色动画
+        // Add random color animation
         function animateCards() {
             const cards = document.querySelectorAll('.game-card');
             cards.forEach((card, index) => {
@@ -203,7 +203,7 @@
             });
         }
 
-        // 添加CSS动画
+        // Add CSS animation class
         const style = document.createElement('style');
         style.textContent = `
             @keyframes pulse {
@@ -214,7 +214,7 @@
         `;
         document.head.appendChild(style);
 
-        // 页面加载完成后添加入场动画
+        // Apply entrance animation after the page loads
         window.addEventListener('load', () => {
             setTimeout(animateCards, 500);
         });


### PR DESCRIPTION
## Summary
- convert the landing experience, metadata, and navigation to English across the homepage and supporting pages
- translate game listings, ranking descriptions, and reusable share components to provide a fully English browsing experience

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9f01cb2f48321b9615af26447655c