### PR TITLE
Add Popular Games artwork and support svg assets

### DIFF
--- a/images/games/merge-flowers.svg
+++ b/images/games/merge-flowers.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675">
+  <defs>
+    <linearGradient id="mf-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffafbd" />
+      <stop offset="100%" stop-color="#ffc3a0" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="675" fill="url(#mf-gradient)" rx="40" ry="40" />
+  <g>
+    <circle cx="320" cy="220" r="110" fill="rgba(255,255,255,0.55)" />
+    <circle cx="440" cy="310" r="140" fill="rgba(255,255,255,0.4)" />
+    <circle cx="720" cy="240" r="120" fill="rgba(255,255,255,0.6)" />
+    <circle cx="880" cy="320" r="150" fill="rgba(255,255,255,0.35)" />
+  </g>
+  <g opacity="0.9">
+    <g transform="translate(240 420)">
+      <circle cx="0" cy="0" r="65" fill="#ff6f91" />
+      <circle cx="60" cy="-10" r="50" fill="#ff9671" />
+      <circle cx="30" cy="50" r="45" fill="#ffd166" />
+    </g>
+    <g transform="translate(880 420)">
+      <circle cx="0" cy="0" r="65" fill="#845ec2" />
+      <circle cx="-60" cy="-10" r="50" fill="#ffc75f" />
+      <circle cx="-30" cy="50" r="45" fill="#f9f871" />
+    </g>
+  </g>
+  <text x="600" y="360" font-family="'Montserrat', 'Arial', sans-serif" font-size="88" font-weight="700" text-anchor="middle" fill="#a23358">Merge Flowers</text>
+  <text x="600" y="435" font-family="'Montserrat', 'Arial', sans-serif" font-size="34" font-weight="500" text-anchor="middle" fill="#713b48" opacity="0.85">Combine blossoms and grow a vibrant garden.</text>
+</svg>

--- a/images/games/obby-on-a-bike.svg
+++ b/images/games/obby-on-a-bike.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675">
+  <defs>
+    <linearGradient id="obb-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4158d0" />
+      <stop offset="50%" stop-color="#c850c0" />
+      <stop offset="100%" stop-color="#ffcc70" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="675" fill="url(#obb-gradient)" rx="40" ry="40" />
+  <g fill="rgba(255,255,255,0.18)">
+    <circle cx="200" cy="180" r="70" />
+    <circle cx="360" cy="120" r="50" />
+    <circle cx="540" cy="190" r="80" />
+    <circle cx="760" cy="140" r="60" />
+    <circle cx="940" cy="200" r="70" />
+  </g>
+  <path d="M80 520 C 240 480, 360 560, 520 520 S 800 460, 1020 520" stroke="#ffffff" stroke-width="16" fill="none" stroke-linecap="round" opacity="0.85" />
+  <path d="M140 540 L260 540" stroke="#ffffff" stroke-width="12" stroke-linecap="round" opacity="0.6" />
+  <path d="M360 560 L480 560" stroke="#ffffff" stroke-width="12" stroke-linecap="round" opacity="0.6" />
+  <path d="M600 540 L720 540" stroke="#ffffff" stroke-width="12" stroke-linecap="round" opacity="0.6" />
+  <path d="M840 560 L960 560" stroke="#ffffff" stroke-width="12" stroke-linecap="round" opacity="0.6" />
+  <text x="600" y="360" font-family="'Montserrat', 'Arial', sans-serif" font-size="90" font-weight="700" text-anchor="middle" fill="#ffffff">Obby On a Bike</text>
+  <text x="600" y="440" font-family="'Montserrat', 'Arial', sans-serif" font-size="34" font-weight="500" text-anchor="middle" fill="#1a1a1a" opacity="0.8">Balance, jump, and stunt across wild obstacle tracks.</text>
+</svg>

--- a/images/games/snow-rush-3d.svg
+++ b/images/games/snow-rush-3d.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675">
+  <defs>
+    <linearGradient id="sr-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4facfe" />
+      <stop offset="100%" stop-color="#00f2fe" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="675" fill="url(#sr-gradient)" rx="40" ry="40" />
+  <g fill="#ffffff" opacity="0.5">
+    <circle cx="200" cy="140" r="80" />
+    <circle cx="360" cy="120" r="60" />
+    <circle cx="520" cy="160" r="90" />
+    <circle cx="880" cy="110" r="70" />
+    <circle cx="1040" cy="150" r="90" />
+  </g>
+  <path d="M0 480 Q 150 360 300 420 T 600 420 T 900 390 T 1200 450 V 675 H0 Z" fill="#ffffff" opacity="0.85" />
+  <path d="M0 520 Q 200 430 400 470 T 800 470 T 1200 510 V 675 H0 Z" fill="#d7f1ff" opacity="0.9" />
+  <text x="600" y="360" font-family="'Montserrat', 'Arial', sans-serif" font-size="88" font-weight="700" text-anchor="middle" fill="#ffffff">Snow Rush 3D</text>
+  <text x="600" y="440" font-family="'Montserrat', 'Arial', sans-serif" font-size="36" font-weight="500" text-anchor="middle" fill="#083766" opacity="0.9">Race across icy slopes and chase the high score!</text>
+</svg>

--- a/images/games/tower-crash-3d.svg
+++ b/images/games/tower-crash-3d.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675">
+  <defs>
+    <linearGradient id="tc-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff9966" />
+      <stop offset="100%" stop-color="#ff5e62" />
+    </linearGradient>
+    <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+      <rect width="60" height="60" fill="rgba(255,255,255,0.05)" />
+      <path d="M0 0 H60 M0 0 V60" stroke="rgba(255,255,255,0.15)" stroke-width="4" />
+    </pattern>
+  </defs>
+  <rect width="1200" height="675" fill="url(#tc-gradient)" rx="40" ry="40" />
+  <rect x="60" y="60" width="1080" height="555" rx="32" ry="32" fill="url(#grid)" />
+  <g fill="#ffffff" opacity="0.25">
+    <rect x="180" y="210" width="120" height="320" rx="16" />
+    <rect x="340" y="160" width="120" height="370" rx="16" />
+    <rect x="500" y="240" width="120" height="290" rx="16" />
+    <rect x="660" y="190" width="120" height="340" rx="16" />
+    <rect x="820" y="220" width="120" height="310" rx="16" />
+  </g>
+  <text x="600" y="360" font-family="'Montserrat', 'Arial', sans-serif" font-size="96" font-weight="800" text-anchor="middle" fill="#ffffff">Tower Crash 3D</text>
+  <text x="600" y="440" font-family="'Montserrat', 'Arial', sans-serif" font-size="34" font-weight="500" text-anchor="middle" fill="#401010" opacity="0.85">Smash the stacked blocks with perfect shots.</text>
+</svg>

--- a/images/games/tunnel-road.svg
+++ b/images/games/tunnel-road.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675">
+  <defs>
+    <linearGradient id="tr-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#141e30" />
+      <stop offset="100%" stop-color="#243b55" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="675" fill="url(#tr-gradient)" rx="40" ry="40" />
+  <g opacity="0.3" fill="none" stroke="#5dade2" stroke-width="6">
+    <path d="M200 600 C 300 400, 900 400, 1000 600" />
+    <path d="M160 600 C 280 350, 920 350, 1040 600" opacity="0.6" />
+    <path d="M120 600 C 260 300, 940 300, 1080 600" opacity="0.3" />
+  </g>
+  <g fill="#1abc9c" opacity="0.4">
+    <circle cx="200" cy="160" r="40" />
+    <circle cx="420" cy="120" r="55" />
+    <circle cx="720" cy="180" r="45" />
+    <circle cx="960" cy="140" r="50" />
+  </g>
+  <path d="M0 520 L1200 520 L1200 675 L0 675 Z" fill="rgba(0,0,0,0.35)" />
+  <path d="M420 520 L600 150 L780 520 Z" fill="rgba(255,255,255,0.08)" />
+  <text x="600" y="360" font-family="'Montserrat', 'Arial', sans-serif" font-size="92" font-weight="700" text-anchor="middle" fill="#ecf0f1">Tunnel Road</text>
+  <text x="600" y="435" font-family="'Montserrat', 'Arial', sans-serif" font-size="34" font-weight="500" text-anchor="middle" fill="#a9c5ff" opacity="0.85">Glide through neon tunnels and dodge every twist.</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -662,7 +662,7 @@
 
         function initializePopularGameImages() {
             const fallbackImage = 'images/games/game-placeholder.svg';
-            const extensions = ['webp', 'jpg', 'jpeg', 'png'];
+            const extensions = ['webp', 'jpg', 'jpeg', 'png', 'svg'];
 
             document.querySelectorAll('#gamesGrid .game-card').forEach(card => {
                 const imgElement = card.querySelector('.game-thumbnail img');


### PR DESCRIPTION
## Summary
- add bespoke SVG cover art files for each Popular Games card under images/games
- extend the dynamic image loader to look for SVG assets so the new artwork is used automatically

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68de39cc7f4483218387cc69a9a02806