### PR TITLE
Add Geometry Dash game page and navigation link

### DIFF
--- a/geometry-dash.html
+++ b/geometry-dash.html
@@ -1,0 +1,252 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Play Geometry Dash online for free. Jump, fly, and flip your way through dangerous passages and spiky obstacles in this rhythm-based action platformer.">
+    <meta name="keywords" content="Geometry Dash, rhythm game, platformer, free online game, arcade game, play Geometry Dash online">
+    <meta name="author" content="Game Studio">
+    <meta name="robots" content="index, follow">
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437" crossorigin="anonymous"></script>
+    <title>Geometry Dash - Play Online | Game Studio</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Arial', sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: #333;
+            min-height: 100vh;
+        }
+
+        .navbar {
+            background: rgba(255, 255, 255, 0.95);
+            backdrop-filter: blur(10px);
+            padding: 1rem 0;
+            position: fixed;
+            width: 100%;
+            top: 0;
+            z-index: 1000;
+            box-shadow: 0 2px 20px rgba(0, 0, 0, 0.1);
+        }
+
+        .nav-container {
+            max-width: 1200px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 0 2rem;
+        }
+
+        .logo {
+            font-size: 1.8rem;
+            font-weight: bold;
+            color: #667eea;
+            text-decoration: none;
+        }
+
+        .nav-links {
+            display: flex;
+            gap: 2rem;
+            list-style: none;
+        }
+
+        .nav-links a {
+            text-decoration: none;
+            color: #333;
+            font-weight: 500;
+            transition: color 0.3s;
+        }
+
+        .nav-links a:hover {
+            color: #667eea;
+        }
+
+        .search-box {
+            display: flex;
+            align-items: center;
+            background: #f8f9fa;
+            border-radius: 25px;
+            padding: 0.5rem 1rem;
+            border: 2px solid transparent;
+            transition: border-color 0.3s;
+        }
+
+        .search-box:focus-within {
+            border-color: #667eea;
+        }
+
+        .search-box input {
+            border: none;
+            background: none;
+            outline: none;
+            padding: 0.5rem;
+            width: 200px;
+        }
+
+        .content {
+            max-width: 1200px;
+            margin: 120px auto 40px;
+            padding: 2rem;
+        }
+
+        .game-hero {
+            text-align: center;
+            color: white;
+            margin-bottom: 2rem;
+        }
+
+        .game-hero h1 {
+            font-size: 3rem;
+            margin-bottom: 1rem;
+            text-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+        }
+
+        .game-hero p {
+            font-size: 1.1rem;
+            max-width: 760px;
+            margin: 0 auto;
+            line-height: 1.6;
+            opacity: 0.9;
+        }
+
+        .game-container {
+            background: rgba(255, 255, 255, 0.95);
+            border-radius: 20px;
+            padding: 1.5rem;
+            box-shadow: 0 15px 35px rgba(0, 0, 0, 0.2);
+        }
+
+        iframe {
+            border: none;
+            width: 100%;
+            height: 550px;
+            border-radius: 15px;
+        }
+
+        .game-tips {
+            margin-top: 2rem;
+            background: rgba(255, 255, 255, 0.9);
+            border-radius: 15px;
+            padding: 1.5rem;
+            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+        }
+
+        .game-tips h2 {
+            font-size: 1.5rem;
+            margin-bottom: 1rem;
+            color: #333;
+        }
+
+        .game-tips ul {
+            list-style: disc inside;
+            color: #444;
+            line-height: 1.6;
+        }
+
+        .footer {
+            background: rgba(0, 0, 0, 0.8);
+            color: white;
+            text-align: center;
+            padding: 2rem;
+            margin-top: 3rem;
+        }
+
+        .footer a {
+            color: #a5b4fc;
+            text-decoration: none;
+        }
+
+        .footer a:hover {
+            color: #c7d2fe;
+        }
+
+        @media (max-width: 768px) {
+            .nav-container {
+                flex-direction: column;
+                gap: 1rem;
+            }
+
+            .nav-links {
+                flex-wrap: wrap;
+                justify-content: center;
+            }
+
+            .content {
+                margin-top: 140px;
+                padding: 1.5rem;
+            }
+
+            .game-hero h1 {
+                font-size: 2.3rem;
+            }
+
+            iframe {
+                height: 420px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <nav class="navbar">
+        <div class="nav-container">
+            <a href="index.html" class="logo">game studio</a>
+            <ul class="nav-links">
+                <li><a href="index.html">Home</a></li>
+                <li><a href="games.html">Games</a></li>
+                <li><a href="featured-games.html">Featured Games</a></li>
+                <li><a href="geometry-dash.html">Geometry Dash</a></li>
+                <li><a href="brain-teasers.html">Brain Teasers</a></li>
+                <li><a href="new-game.html">New Releases</a></li>
+                <li><a href="game-development.html">Game Development</a></li>
+                <li><a href="company-ranking.html">Company Rankings</a></li>
+            </ul>
+            <div class="search-box">
+                <input type="text" placeholder="Search games..." aria-label="Search games">
+                <span>🔍</span>
+            </div>
+        </div>
+    </nav>
+
+    <main class="content">
+        <section class="game-hero">
+            <h1>Geometry Dash</h1>
+            <p>Experience the fast-paced rhythm platformer that tests your timing and reflexes. Jump and fly through obstacles while enjoying an energetic soundtrack and vibrant visuals.</p>
+        </section>
+
+        <section class="game-container" aria-label="Geometry Dash game">
+            <iframe
+              src="https://1games.io/game/geometry-lite/"
+              width="100%"
+              height="550"
+              frameborder="0"
+              loading="lazy"
+              allow="autoplay; fullscreen; gamepad; picture-in-picture; encrypted-media"
+              sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals allow-pointer-lock allow-downloads allow-presentation">
+            </iframe>
+        </section>
+
+        <section class="game-tips">
+            <h2>How to Play</h2>
+            <ul>
+                <li>Tap or click to jump and avoid obstacles in sync with the beat.</li>
+                <li>Hold to perform longer jumps and navigate tricky sequences.</li>
+                <li>Use practice mode to master challenging sections before going for a full run.</li>
+            </ul>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <p>&copy; <span id="year"></span> Game Studio. All rights reserved. <a href="index.html">Back to Home</a></p>
+    </footer>
+
+    <script>
+        document.getElementById('year').textContent = new Date().getFullYear();
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -503,6 +503,7 @@
                 <li><a href="index.html">Home</a></li>
                 <li><a href="games.html">Games</a></li>
                 <li><a href="featured-games.html">Featured Games</a></li>
+                <li><a href="geometry-dash.html">Geometry Dash</a></li>
                 <li><a href="brain-teasers.html">Brain Teasers</a></li>
                 <li><a href="new-game.html">New Releases</a></li>
                 <li><a href="game-development.html">Game Development</a></li>


### PR DESCRIPTION
## Summary
- create a dedicated Geometry Dash landing page with an embedded playable iframe and gameplay tips
- mirror existing navigation styling so the new page is consistent with the rest of the site
- add a Geometry Dash entry to the home page navigation menu for quick access

## Testing
- manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e141cf700883219bf4def93cd7963b