### PR TITLE
Add Geometry Dash landing page and navigation entry

### DIFF
--- a/Browser.html
+++ b/Browser.html
@@ -174,6 +174,7 @@
                 <li><a href="index.html">Home</a></li>
                 <li><a href="games.html">Games</a></li>
                 <li><a href="featured-games.html">Featured Games</a></li>
+                <li><a href="geometry-dash.html">Geometry Dash</a></li>
                 <li><a href="brain-teasers.html">Brain Teasers</a></li>
                 <li><a href="#categories">Categories</a></li>
                 <li><a href="#new">New</a></li>

--- a/IFRAMGAME.html
+++ b/IFRAMGAME.html
@@ -142,6 +142,7 @@
                 <li><a href="index.html">Home</a></li>
                 <li><a href="games.html">Games</a></li>
                 <li><a href="featured-games.html">Featured Games</a></li>
+                <li><a href="geometry-dash.html">Geometry Dash</a></li>
                 <li><a href="brain-teasers.html">Brain Teasers</a></li>
                 <li><a href="#categories">Categories</a></li>
                 <li><a href="#new">New</a></li>

--- a/brain-teasers.html
+++ b/brain-teasers.html
@@ -229,6 +229,7 @@
                 <li><a href="index.html">Home</a></li>
                 <li><a href="games.html">Games</a></li>
                 <li><a href="featured-games.html">Featured Games</a></li>
+                <li><a href="geometry-dash.html">Geometry Dash</a></li>
                 <li><a href="brain-teasers.html">Brain Teasers</a></li>
                 <li><a href="new-game.html">New Releases</a></li>
                 <li><a href="game-development.html">Game Development</a></li>

--- a/company-ranking.html
+++ b/company-ranking.html
@@ -301,6 +301,7 @@
                 <li><a href="index.html">Home</a></li>
                 <li><a href="games.html">Games</a></li>
                 <li><a href="featured-games.html">Featured Games</a></li>
+                <li><a href="geometry-dash.html">Geometry Dash</a></li>
                 <li><a href="brain-teasers.html">Brain Teasers</a></li>
                 <li><a href="#categories">Categories</a></li>
                 <li><a href="#new">New</a></li>

--- a/featured-games.html
+++ b/featured-games.html
@@ -220,6 +220,7 @@
                 <li><a href="index.html">Home</a></li>
                 <li><a href="games.html">Games</a></li>
                 <li><a href="featured-games.html">Featured Games</a></li>
+                <li><a href="geometry-dash.html">Geometry Dash</a></li>
                 <li><a href="brain-teasers.html">Brain Teasers</a></li>
                 <li><a href="new-game.html">New Releases</a></li>
                 <li><a href="game-development.html">Game Development</a></li>

--- a/game-development.html
+++ b/game-development.html
@@ -186,6 +186,7 @@
                 <li><a href="index.html">Home</a></li>
                 <li><a href="games.html">Games</a></li>
                 <li><a href="featured-games.html">Featured Games</a></li>
+                <li><a href="geometry-dash.html">Geometry Dash</a></li>
                 <li><a href="brain-teasers.html">Brain Teasers</a></li>
                 <li><a href="new-game.html">New Releases</a></li>
                 <li><a href="game-development.html">Game Development</a></li>

--- a/games.html
+++ b/games.html
@@ -179,6 +179,7 @@
                 <li><a href="index.html">Home</a></li>
                 <li><a href="games.html">Games</a></li>
                 <li><a href="featured-games.html">Featured Games</a></li>
+                <li><a href="geometry-dash.html">Geometry Dash</a></li>
                 <li><a href="brain-teasers.html">Brain Teasers</a></li>
                 <li><a href="#categories">Categories</a></li>
                 <li><a href="#new">New</a></li>

--- a/geometry-dash.html
+++ b/geometry-dash.html
@@ -1,0 +1,345 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Play Geometry Dash online for free at Game Studio. Jump, fly, and flip your way through rhythm-based platforming challenges directly in your browser.">
+    <meta name="keywords" content="Geometry Dash, Geometry Lite, rhythm game, platformer, online game, browser game, free game, skill game">
+    <meta name="author" content="Game Studio">
+    <meta name="robots" content="index, follow">
+    <title>Geometry Dash Online - Play Free Rhythm Platformer | Game Studio</title>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437" crossorigin="anonymous"></script>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Arial', sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: #333;
+            min-height: 100vh;
+        }
+
+        .navbar {
+            background: rgba(255, 255, 255, 0.95);
+            backdrop-filter: blur(10px);
+            padding: 1rem 0;
+            position: fixed;
+            width: 100%;
+            top: 0;
+            z-index: 1000;
+            box-shadow: 0 2px 20px rgba(0, 0, 0, 0.1);
+        }
+
+        .nav-container {
+            max-width: 1200px;
+            margin: 0 auto;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 0 2rem;
+        }
+
+        .logo {
+            font-size: 1.8rem;
+            font-weight: bold;
+            color: #667eea;
+            text-decoration: none;
+        }
+
+        .nav-links {
+            display: flex;
+            gap: 2rem;
+            list-style: none;
+        }
+
+        .nav-links a {
+            text-decoration: none;
+            color: #333;
+            font-weight: 500;
+            transition: color 0.3s;
+        }
+
+        .nav-links a:hover {
+            color: #667eea;
+        }
+
+        .search-box {
+            display: flex;
+            align-items: center;
+            background: #f8f9fa;
+            border-radius: 25px;
+            padding: 0.5rem 1rem;
+            border: 2px solid transparent;
+            transition: border-color 0.3s;
+        }
+
+        .search-box:focus-within {
+            border-color: #667eea;
+        }
+
+        .search-box input {
+            border: none;
+            background: none;
+            outline: none;
+            padding: 0.5rem;
+            width: 200px;
+        }
+
+        .mobile-menu {
+            display: none;
+            background: none;
+            border: none;
+            font-size: 1.5rem;
+            color: #333;
+        }
+
+        .content {
+            max-width: 1100px;
+            margin: 120px auto 0;
+            padding: 2rem;
+        }
+
+        .hero {
+            background: rgba(255, 255, 255, 0.9);
+            border-radius: 25px;
+            padding: 2.5rem;
+            box-shadow: 0 15px 35px rgba(0, 0, 0, 0.15);
+            text-align: center;
+            margin-bottom: 2.5rem;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .hero::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: linear-gradient(135deg, rgba(102, 126, 234, 0.2), rgba(118, 75, 162, 0.2));
+            z-index: 0;
+        }
+
+        .hero h1 {
+            font-size: 2.8rem;
+            color: #333;
+            margin-bottom: 1rem;
+            position: relative;
+            z-index: 1;
+        }
+
+        .hero p {
+            font-size: 1.1rem;
+            color: #555;
+            max-width: 700px;
+            margin: 0 auto;
+            position: relative;
+            z-index: 1;
+            line-height: 1.6;
+        }
+
+        .game-container {
+            background: rgba(255, 255, 255, 0.95);
+            border-radius: 25px;
+            padding: 2rem;
+            box-shadow: 0 20px 45px rgba(0, 0, 0, 0.12);
+            margin-bottom: 2.5rem;
+        }
+
+        .game-container h2 {
+            font-size: 2rem;
+            margin-bottom: 1rem;
+            color: #333;
+            text-align: center;
+        }
+
+        .iframe-wrapper {
+            position: relative;
+            width: 100%;
+            border-radius: 20px;
+            overflow: hidden;
+            box-shadow: 0 15px 30px rgba(102, 126, 234, 0.25);
+            background: #000;
+        }
+
+        .iframe-wrapper iframe {
+            width: 100%;
+            height: 550px;
+            border: none;
+        }
+
+        .tips-section {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: 1.5rem;
+        }
+
+        .tip-card {
+            background: rgba(255, 255, 255, 0.92);
+            border-radius: 20px;
+            padding: 1.5rem;
+            box-shadow: 0 12px 28px rgba(0, 0, 0, 0.12);
+        }
+
+        .tip-card h3 {
+            font-size: 1.3rem;
+            margin-bottom: 0.75rem;
+            color: #667eea;
+        }
+
+        .tip-card p {
+            color: #555;
+            line-height: 1.6;
+            font-size: 0.95rem;
+        }
+
+        .footer {
+            text-align: center;
+            padding: 2rem;
+            color: rgba(255, 255, 255, 0.9);
+            font-size: 0.9rem;
+        }
+
+        @media (max-width: 992px) {
+            .nav-container {
+                padding: 0 1.5rem;
+            }
+
+            .hero h1 {
+                font-size: 2.3rem;
+            }
+        }
+
+        @media (max-width: 768px) {
+            .nav-links {
+                display: none;
+                position: absolute;
+                top: 70px;
+                right: 20px;
+                background: rgba(255, 255, 255, 0.97);
+                flex-direction: column;
+                padding: 1.5rem;
+                border-radius: 15px;
+                box-shadow: 0 15px 30px rgba(0, 0, 0, 0.12);
+            }
+
+            .nav-links li {
+                margin-bottom: 1rem;
+            }
+
+            .nav-links li:last-child {
+                margin-bottom: 0;
+            }
+
+            .mobile-menu {
+                display: block;
+            }
+
+            .search-box {
+                display: none;
+            }
+
+            .content {
+                padding: 1.5rem 1rem;
+                margin-top: 100px;
+            }
+
+            .iframe-wrapper iframe {
+                height: 420px;
+            }
+        }
+
+        @media (max-width: 480px) {
+            .hero h1 {
+                font-size: 2rem;
+            }
+
+            .iframe-wrapper iframe {
+                height: 360px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <nav class="navbar">
+        <div class="nav-container">
+            <a href="index.html" class="logo">game studio</a>
+            <ul class="nav-links">
+                <li><a href="index.html">Home</a></li>
+                <li><a href="games.html">Games</a></li>
+                <li><a href="featured-games.html">Featured Games</a></li>
+                <li><a href="geometry-dash.html">Geometry Dash</a></li>
+                <li><a href="brain-teasers.html">Brain Teasers</a></li>
+                <li><a href="new-game.html">New Releases</a></li>
+                <li><a href="game-development.html">Game Development</a></li>
+                <li><a href="company-ranking.html">Company Rankings</a></li>
+            </ul>
+            <div class="search-box">
+                <input type="text" placeholder="Search games..." aria-label="Search games">
+                <span>🔍</span>
+            </div>
+            <button class="mobile-menu" aria-label="Toggle navigation">☰</button>
+        </div>
+    </nav>
+
+    <main class="content">
+        <header class="hero">
+            <h1>Geometry Dash Online</h1>
+            <p>Leap over obstacles, fly through danger zones, and sync every move to the beat in this fast-paced rhythm platformer. Enjoy the Geometry Dash experience directly in your browser—no downloads required.</p>
+        </header>
+
+        <section class="game-container" aria-labelledby="play-geometry-dash">
+            <h2 id="play-geometry-dash">Play Geometry Dash</h2>
+            <div class="iframe-wrapper">
+                <iframe
+                    src="https://1games.io/game/geometry-lite/"
+                    width="100%"
+                    height="550"
+                    frameborder="0"
+                    loading="lazy"
+                    allow="autoplay; fullscreen; gamepad; picture-in-picture; encrypted-media"
+                    sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals allow-pointer-lock allow-downloads allow-presentation"
+                    title="Geometry Dash Online Game">
+                </iframe>
+            </div>
+        </section>
+
+        <section class="tips-section" aria-label="Gameplay tips">
+            <article class="tip-card">
+                <h3>Master the Rhythm</h3>
+                <p>Geometry Dash levels are built around the soundtrack. Keep your focus on the beat to time jumps perfectly and anticipate upcoming hazards.</p>
+            </article>
+            <article class="tip-card">
+                <h3>Practice Makes Perfect</h3>
+                <p>Use the practice mode to place checkpoints and memorize tricky sections. Repetition helps build the muscle memory needed for flawless runs.</p>
+            </article>
+            <article class="tip-card">
+                <h3>Switch Up Your Icons</h3>
+                <p>Unlock and customize icons as you progress to showcase your skills. Personalized icons bring extra flair to every victory.</p>
+            </article>
+        </section>
+    </main>
+
+    <footer class="footer">
+        © <span id="currentYear"></span> Game Studio. All rights reserved.
+    </footer>
+
+    <script>
+        const mobileMenuButton = document.querySelector('.mobile-menu');
+        const navLinks = document.querySelector('.nav-links');
+
+        mobileMenuButton.addEventListener('click', () => {
+            const isExpanded = navLinks.style.display === 'flex';
+            navLinks.style.display = isExpanded ? 'none' : 'flex';
+            if (!isExpanded) {
+                navLinks.style.flexDirection = 'column';
+                navLinks.style.gap = '1rem';
+            }
+        });
+
+        document.getElementById('currentYear').textContent = new Date().getFullYear();
+    </script>
+</body>
+</html>

--- a/index-copy.html
+++ b/index-copy.html
@@ -313,6 +313,7 @@
             <ul class="nav-links">
                 <li><a href="#home">Home</a></li>
                 <li><a href="games.html">Games</a></li>
+                <li><a href="geometry-dash.html">Geometry Dash</a></li>
                 <li><a href="#categories">Categories</a></li>
                 <li><a href="#new">New</a></li>
                 <li><a href="#popular">Popular</a></li>

--- a/index.html
+++ b/index.html
@@ -503,6 +503,7 @@
                 <li><a href="index.html">Home</a></li>
                 <li><a href="games.html">Games</a></li>
                 <li><a href="featured-games.html">Featured Games</a></li>
+                <li><a href="geometry-dash.html">Geometry Dash</a></li>
                 <li><a href="brain-teasers.html">Brain Teasers</a></li>
                 <li><a href="new-game.html">New Releases</a></li>
                 <li><a href="game-development.html">Game Development</a></li>

--- a/new-game.html
+++ b/new-game.html
@@ -346,6 +346,7 @@
                 <li><a href="index.html">Home</a></li>
                 <li><a href="games.html">Games</a></li>
                 <li><a href="featured-games.html">Featured Games</a></li>
+                <li><a href="geometry-dash.html">Geometry Dash</a></li>
                 <li><a href="brain-teasers.html">Brain Teasers</a></li>
                 <li><a href="new-game.html">New Releases</a></li>
                 <li><a href="top-games.html">Top Games</a></li>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -31,6 +31,12 @@
         <priority>0.8</priority>
     </url>
     <url>
+        <loc>https://youxistudio.online/geometry-dash.html</loc>
+        <lastmod>2025-10-02</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
         <loc>https://youxistudio.online/top-games.html</loc>
         <lastmod>2025-10-02</lastmod>
         <changefreq>weekly</changefreq>


### PR DESCRIPTION
## Summary
- create a dedicated Geometry Dash page featuring an embedded playable iframe and supporting content
- update the site-wide navigation menus to link to the new Geometry Dash experience
- register the new page within the sitemap for discovery

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e1415d98a0832189c6ba71618c8310