### PR TITLE
Add Mancala single-page game experience

### DIFF
--- a/games/Mancala/index.html
+++ b/games/Mancala/index.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mancala – Play Online</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;700&family=Poppins:wght@300;400;500;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg-gradient: linear-gradient(135deg, #0f2027, #203a43, #2c5364);
+      --accent: #ffd166;
+      --accent-dark: #f6ae2d;
+      --text-primary: #f4f9ff;
+      --text-secondary: #d8e1e9;
+      --card-bg: rgba(15, 32, 39, 0.8);
+      --glass-border: rgba(255, 255, 255, 0.1);
+      --shadow: 0 30px 60px rgba(0, 0, 0, 0.45);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Poppins', sans-serif;
+      background: var(--bg-gradient);
+      color: var(--text-primary);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    header {
+      padding: 2.5rem 8vw 1.5rem;
+      text-align: center;
+    }
+
+    header h1 {
+      font-family: 'Playfair Display', serif;
+      font-size: clamp(2.5rem, 5vw, 3.5rem);
+      margin: 0;
+      letter-spacing: 1px;
+    }
+
+    header p {
+      margin: 1rem auto 0;
+      max-width: 650px;
+      font-size: 1.05rem;
+      color: var(--text-secondary);
+      line-height: 1.6;
+    }
+
+    main {
+      flex: 1;
+      display: grid;
+      gap: 2.5rem;
+      padding: 0 8vw 4rem;
+      grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      align-items: start;
+    }
+
+    .game-frame,
+    .rules-card {
+      background: var(--card-bg);
+      border: 1px solid var(--glass-border);
+      border-radius: 26px;
+      box-shadow: var(--shadow);
+      overflow: hidden;
+      backdrop-filter: blur(12px);
+    }
+
+    .game-frame header {
+      padding: 1.25rem 1.75rem 0.75rem;
+      text-align: left;
+    }
+
+    .game-frame h2 {
+      margin: 0;
+      font-size: 1.75rem;
+    }
+
+    .game-wrapper {
+      padding: 0 1.75rem 1.75rem;
+    }
+
+    .game-wrapper iframe {
+      width: 100%;
+      min-height: 540px;
+      border: none;
+      border-radius: 18px;
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+    }
+
+    .rules-card {
+      padding: 2.25rem;
+    }
+
+    .rules-card h2 {
+      margin-top: 0;
+      font-size: 1.65rem;
+    }
+
+    .rules-section + .rules-section {
+      margin-top: 1.75rem;
+    }
+
+    .rules-section h3 {
+      font-size: 1.2rem;
+      letter-spacing: 0.03em;
+      margin: 0 0 0.6rem;
+      text-transform: uppercase;
+      color: var(--accent);
+    }
+
+    .rules-section p,
+    .rules-section ul {
+      margin: 0;
+      font-size: 1rem;
+      line-height: 1.7;
+      color: var(--text-secondary);
+    }
+
+    .rules-section ul {
+      padding-left: 1.2rem;
+    }
+
+    .play-now {
+      margin-top: 2.5rem;
+      display: flex;
+      justify-content: center;
+    }
+
+    .play-now a {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.65rem;
+      padding: 0.9rem 1.9rem;
+      border-radius: 999px;
+      background: linear-gradient(135deg, var(--accent), var(--accent-dark));
+      color: #2c1608;
+      font-weight: 600;
+      text-decoration: none;
+      letter-spacing: 0.04em;
+      box-shadow: 0 18px 35px rgba(0, 0, 0, 0.25);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .play-now a:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 22px 40px rgba(0, 0, 0, 0.28);
+    }
+
+    footer {
+      text-align: center;
+      padding: 2rem 1rem 3rem;
+      color: rgba(244, 249, 255, 0.6);
+      font-size: 0.95rem;
+    }
+
+    @media (max-width: 768px) {
+      header {
+        padding: 2.5rem 6vw 1.5rem;
+      }
+
+      main {
+        padding: 0 6vw 3rem;
+      }
+
+      .rules-card {
+        padding: 2rem 1.75rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Mancala</h1>
+    <p>Rediscover the timeless strategy of Mancala with a polished 3D presentation. Challenge a clever AI, plan your perfect capture, and enjoy a serene tabletop experience wherever you are.</p>
+  </header>
+
+  <main>
+    <section class="game-frame">
+      <header>
+        <h2>Play in Your Browser</h2>
+        <p>Drop stones, earn extra turns, and capture your opponent&rsquo;s pieces in this immersive digital classic.</p>
+      </header>
+      <div class="game-wrapper">
+        <iframe src="https://html5.gamedistribution.com/a2f973472a0f48668039ed366e2a26e8/?gd_sdk_referrer_url=https://www.example.com/games/{game-path}" width="900" height="600" scrolling="none" frameborder="0" allowfullscreen></iframe>
+      </div>
+    </section>
+
+    <section class="rules-card">
+      <h2>Mancala Game Rules</h2>
+
+      <div class="rules-section">
+        <h3>🎯 Objective</h3>
+        <p>The goal of Mancala is to collect more stones in your store (the large pit on your right) than your opponent by the end of the game.</p>
+      </div>
+
+      <div class="rules-section">
+        <h3>🧩 Game Setup</h3>
+        <ul>
+          <li>The board has two rows of six pits each.</li>
+          <li>Each small pit starts with four stones.</li>
+          <li>The large pits (stores) at each end belong to the players.</li>
+          <li>You control the six pits on your side and the store on your right.</li>
+        </ul>
+      </div>
+
+      <div class="rules-section">
+        <h3>🔄 Gameplay</h3>
+        <ul>
+          <li>On your turn, pick up all stones from one of your pits.</li>
+          <li>Move counterclockwise, dropping one stone into each pit as you go.</li>
+          <li>Skip your opponent’s store, but place stones in your own store when passing it.</li>
+          <li>If your last stone lands in your own store, you get another turn.</li>
+          <li>If your last stone lands in an empty pit on your side, you capture that stone and any stones in the opposite pit, placing them in your store.</li>
+        </ul>
+      </div>
+
+      <div class="rules-section">
+        <h3>🛑 Game End</h3>
+        <ul>
+          <li>The game ends when one side’s six pits are empty.</li>
+          <li>The player with stones remaining on their side collects them into their store.</li>
+          <li>The winner is the one with the most stones in their store.</li>
+        </ul>
+      </div>
+
+      <div class="rules-section">
+        <h3>💡 Tips for Winning</h3>
+        <ul>
+          <li>Try to end your turn in your store to earn an extra move.</li>
+          <li>Watch your opponent’s moves to avoid letting them capture.</li>
+          <li>Plan ahead — sometimes skipping a big capture now leads to a better one later.</li>
+        </ul>
+      </div>
+
+      <div class="rules-section">
+        <h3>🎮 Play Now</h3>
+        <p>Experience this classic game in full 3D — beautiful visuals, smart AI, and endless strategy fun. 👉 Play free at Mancala.online</p>
+      </div>
+    </section>
+  </main>
+
+  <div class="play-now">
+    <a href="https://mancala.online" target="_blank" rel="noopener">Start a Match</a>
+  </div>
+
+  <footer>
+    Crafted with ❤️ for strategy lovers everywhere.
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create the games/Mancala directory with a polished single-page layout
- embed the Mancala game via GameDistribution iframe and present full rules and tips
- add stylized call-to-action and responsive design elements for a premium feel

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5cf0df24083219696b3c77f1e059f