### PR TITLE
Add Google AdSense script to site HTML pages

### DIFF
--- a/about-us.html
+++ b/about-us.html
@@ -291,6 +291,8 @@
             }
         }
     </style>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437"
+     crossorigin="anonymous"></script>
 </head>
 <body>
     <header>

--- a/brain-teasers.html
+++ b/brain-teasers.html
@@ -278,6 +278,8 @@
             50% { transform: translateY(-20px) rotate(180deg); }
         }
     </style>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437"
+     crossorigin="anonymous"></script>
 </head>
 <body>
     <div class="floating-elements" aria-hidden="true">

--- a/classicgames.html
+++ b/classicgames.html
@@ -199,6 +199,8 @@
             }
         }
     </style>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437"
+     crossorigin="anonymous"></script>
 </head>
 <body>
     <header>

--- a/extremepamplona.html
+++ b/extremepamplona.html
@@ -558,6 +558,8 @@
             }
         }
     </style>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437"
+     crossorigin="anonymous"></script>
 </head>
 <body>
     <nav class="navbar">

--- a/featured-games.html
+++ b/featured-games.html
@@ -269,6 +269,8 @@
             50% { transform: translateY(-20px) rotate(180deg); }
         }
     </style>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437"
+     crossorigin="anonymous"></script>
 </head>
 <body>
     <div class="floating-elements" aria-hidden="true">

--- a/games/Mancala/index.html
+++ b/games/Mancala/index.html
@@ -225,6 +225,8 @@
       }
     }
   </style>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437"
+     crossorigin="anonymous"></script>
 </head>
 <body>
   <header>

--- a/geometry-dash.html
+++ b/geometry-dash.html
@@ -326,6 +326,8 @@
             }
         }
     </style>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437"
+     crossorigin="anonymous"></script>
 </head>
 <body>
     <nav class="navbar">

--- a/index.html
+++ b/index.html
@@ -780,6 +780,8 @@
             }
         }
     </style>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437"
+     crossorigin="anonymous"></script>
 </head>
 <body>
     <div class="page">

--- a/marketing-hub.html
+++ b/marketing-hub.html
@@ -385,6 +385,8 @@
             }
         }
     </style>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437"
+     crossorigin="anonymous"></script>
 </head>
 <body>
     <header>

--- a/share-component.html
+++ b/share-component.html
@@ -1,3 +1,5 @@
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437"
+     crossorigin="anonymous"></script>
 <!-- Social media sharing component -->
 <!-- Usage: copy this snippet into any page where sharing is needed -->
 

--- a/snakes.html
+++ b/snakes.html
@@ -273,6 +273,8 @@
             }
         }
     </style>
+<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437"
+     crossorigin="anonymous"></script>
 </head>
 <body>
     <nav class="navbar">


### PR DESCRIPTION
### Motivation
- Enable Google AdSense across the static site so the publisher script is loaded on primary pages and shared components.

### Description
- Insert the AdSense script tag `<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8794607118520437" crossorigin="anonymous"></script>` into site HTML pages.
- The script was added just before the closing `</head>` in multiple pages and placed at the top of the shared `share-component.html` where applicable.
- Affected files include 11 HTML pages such as `index.html`, `marketing-hub.html`, `games/Mancala/index.html`, `about-us.html`, `featured-games.html`, `classicgames.html`, `brain-teasers.html`, `geometry-dash.html`, `extremepamplona.html`, `snakes.html`, and `share-component.html`.

### Testing
- A site-wide update script (`python`) was run to insert the snippet and it reported the list of updated files successfully.
- A recursive search for the AdSense URL (`rg` / script check) was executed to confirm the snippet is present in all HTML files and returned no missing files.
- There are no unit tests for this static HTML change and no runtime tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970231114ec8321b5ae95fb0c8a7ab5)